### PR TITLE
Wait for startup of arduino

### DIFF
--- a/pnpbridge/src/adapters/src/serial_pnp/serial_pnp.c
+++ b/pnpbridge/src/adapters/src/serial_pnp/serial_pnp.c
@@ -1008,6 +1008,7 @@ int SerialPnp_OpenDevice(const char* port, DWORD baudRate)
 
     set_interface_attribs(fd, B115200, 0);  // set speed to 115,200 bps, 8n1 (no parity)
     //set_blocking(fd, 1);  // set no blocking
+	ThreadAPI_Sleep(3000);
 #endif
 
     PSERIAL_DEVICE_CONTEXT deviceContext = malloc(sizeof(SERIAL_DEVICE_CONTEXT));


### PR DESCRIPTION
#30 
When open serial port, reset the arduino.
We need to wait (or receive timeout and retry).
