### PR TITLE
Adding IoT Edge Module support for Pnp Bridge

### DIFF
--- a/pnpbridge/Dockerfile.amd64
+++ b/pnpbridge/Dockerfile.amd64
@@ -1,0 +1,23 @@
+FROM ubuntu:xenial AS base
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends software-properties-common && \
+    add-apt-repository -y ppa:aziotsdklinux/ppa-azureiot && \
+    apt-get update && \
+    apt-get install -y azure-iot-sdk-c-dev && \
+    rm -rf /var/lib/apt/lists/*
+
+FROM base AS build-env
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends cmake gcc g++ make && \
+    rm -rf /var/lib/apt/lists/* 
+WORKDIR /app
+COPY . ./
+RUN ./scripts/linux/build.sh
+
+FROM base
+WORKDIR /app
+COPY --from=build-env /app ./
+RUN useradd -ms /bin/bash moduleuser
+USER moduleuser
+ENV IOTHUB_DEVICE_CONNECTION_STRING="<ADD CONNECTION STRING HERE>"
+CMD ["./cmake/pnpbridge_linux/src/pnpbridge/module/pnpbridge_module"]

--- a/pnpbridge/Dockerfile.amd64.debug
+++ b/pnpbridge/Dockerfile.amd64.debug
@@ -1,0 +1,21 @@
+FROM ubuntu:xenial AS base
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends software-properties-common gdb && \
+    add-apt-repository -y ppa:aziotsdklinux/ppa-azureiot && \
+    apt-get update && \
+    apt-get install -y azure-iot-sdk-c-dev && \
+    rm -rf /var/lib/apt/lists/*
+
+FROM base AS build-env
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends cmake gcc g++ make && \
+    rm -rf /var/lib/apt/lists/* 
+WORKDIR /app
+COPY . ./src/pnpbridge/module 
+RUN cmake -DCMAKE_BUILD_TYPE=Debug ./src/pnpbridge/module
+RUN make
+
+FROM base
+WORKDIR /app
+COPY --from=build-env /app ./
+CMD ["./pnpbridge_module"]

--- a/pnpbridge/Dockerfile.arm32v7
+++ b/pnpbridge/Dockerfile.arm32v7
@@ -1,0 +1,23 @@
+FROM arm32v7/ubuntu:xenial AS base
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends software-properties-common && \
+    add-apt-repository -y ppa:aziotsdklinux/ppa-azureiot && \
+    apt-get update && \
+    apt-get install -y azure-iot-sdk-c-dev && \
+    rm -rf /var/lib/apt/lists/*
+
+FROM base AS build-env
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends cmake gcc g++ make && \
+    rm -rf /var/lib/apt/lists/* 
+WORKDIR /app
+COPY . ./src/pnpbridge/module
+RUN cmake .src/pnpbridge/module 
+RUN make
+
+FROM base
+WORKDIR /app
+COPY --from=build-env /app ./
+RUN useradd -ms /bin/bash moduleuser
+USER moduleuser
+CMD ["./pnpbridge_module"]

--- a/pnpbridge/Dockerfile.arm64v8
+++ b/pnpbridge/Dockerfile.arm64v8
@@ -1,0 +1,23 @@
+FROM arm64v8/ubuntu:xenial AS base
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends software-properties-common && \
+    add-apt-repository -y ppa:aziotsdklinux/ppa-azureiot && \
+    apt-get update && \
+    apt-get install -y azure-iot-sdk-c-dev && \
+    rm -rf /var/lib/apt/lists/*
+
+FROM base AS build-env
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends cmake gcc g++ make && \
+    rm -rf /var/lib/apt/lists/* 
+WORKDIR /app
+COPY . ./src/pnpbridge/module
+RUN cmake .src/pnpbridge/module 
+RUN make
+
+FROM base
+WORKDIR /app
+COPY --from=build-env /app ./
+RUN useradd -ms /bin/bash moduleuser
+USER moduleuser
+CMD ["./pnpbridge_module"]

--- a/pnpbridge/deployment.debug.template.json
+++ b/pnpbridge/deployment.debug.template.json
@@ -1,0 +1,315 @@
+{
+  "$schema-template": "2.0.0",
+  "modulesContent": {
+    "$edgeAgent": {
+      "properties.desired": {
+        "schemaVersion": "1.0",
+        "runtime": {
+          "type": "docker",
+          "settings": {
+            "minDockerVersion": "v1.25",
+            "loggingOptions": "",
+            "registryCredentials": {
+              "pnpbridge": {
+                "username": "$CONTAINER_REGISTRY_USERNAME_pnpbridge",
+                "password": "$CONTAINER_REGISTRY_PASSWORD_pnpbridge",
+                "address": "<ADD CONTAINER REGISTRY ADDRESS HERE>"
+              }
+            }
+          }
+        },
+        "systemModules": {
+          "edgeAgent": {
+            "type": "docker",
+            "settings": {
+              "image": "mcr.microsoft.com/azureiotedge-agent:1.0",
+              "createOptions": {}
+            }
+          },
+          "edgeHub": {
+            "type": "docker",
+            "status": "running",
+            "restartPolicy": "always",
+            "settings": {
+              "image": "mcr.microsoft.com/azureiotedge-hub:1.0",
+              "createOptions": {
+                "HostConfig": {
+                  "PortBindings": {
+                    "5671/tcp": [
+                      {
+                        "HostPort": "5671"
+                      }
+                    ],
+                    "8883/tcp": [
+                      {
+                        "HostPort": "8883"
+                      }
+                    ],
+                    "443/tcp": [
+                      {
+                        "HostPort": "443"
+                      }
+                    ]
+                  }
+                }
+              }
+            }
+          }
+        },
+        "modules": {
+          "PnPBridgeModule": {
+            "version": "1.0",
+            "type": "docker",
+            "status": "running",
+            "restartPolicy": "always",
+            "settings": {
+              "image": "<ADD MODULE IMAGE HERE>",
+              "createOptions": {
+                "HostConfig": {
+                  "Privileged": true
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "$edgeHub": {
+      "properties.desired": {
+        "schemaVersion": "1.0",
+        "routes": {
+          "PnPBridgeModuleToIoTHub": "FROM /messages/modules/PnPBridgeModule/outputs/* INTO $upstream"
+        },
+        "storeAndForwardConfiguration": {
+          "timeToLiveSecs": 7200
+        }
+      }
+    },
+    "PnPBridgeModule": {
+      "properties.desired": {
+        "PnpBridgeConfig": {
+            "pnp_bridge_debug_trace": false,
+            "pnp_bridge_config_source": "local",
+            "pnp_bridge_interface_components": [
+                {
+                    "_comment": "Component 1 - Modbus Device",
+                    "pnp_bridge_component_name": "Co2Detector1",
+                    "pnp_bridge_adapter_id": "modbus-pnp-interface",
+                    "pnp_bridge_adapter_config": {
+                        "unit_id": 1,
+                        "rtu": null,
+                        "tcp": {
+                            "host": "10.159.29.9",
+                            "port": 502
+                        },
+                        "modbus_identity": "DL679"
+                    }
+                },
+                {
+                    "_comment": "Component 2 - USB device",
+                    "pnp_bridge_component_name": "coredevicehealth1",
+                    "pnp_bridge_adapter_id": "core-device-health",
+                    "pnp_bridge_adapter_config": {
+                        "hardware_id": "USB\\VID_06CB&PID_00B3"
+                    }
+                },
+                {
+                    "_comment": "Component 3 - MCU sensor hub which reports Azure IoT Pnp interfaces",
+                    "pnp_bridge_component_name": "serialpnp1",
+                    "pnp_bridge_adapter_id": "serial-pnp-interface",
+                    "pnp_bridge_adapter_config": {
+                        "com_port": "COM1",
+                        "_comment": "NOTE: com_port parameter will NOT be used when use_com_device_interface is set to true. In case of windows iot edition, the COMXX symbolic links are not created. Setting use_com_device_interface to false will pick the first available COM interface.",
+                        "use_com_device_interface": "false",
+                        "baud_rate": "115200"
+                    }
+                },
+                {
+                    "_comment": "Component 4 - Standard Video Camera connected to a PC, for now the first camera only.",
+                    "pnp_bridge_component_name": "cameracomponent",
+                    "pnp_bridge_adapter_id": "camera-pnp-adapter",
+                    "pnp_bridge_adapter_config": {
+                        "hardware_id": "UVC_Webcam_00"
+                    }
+                },
+                {
+                    "_comment": "Component 5 - Ruuvi Instance 1",
+                    "pnp_bridge_component_name": "ruuvi1",
+                    "pnp_bridge_adapter_id": "bluetooth-sensor-pnp-adapter",
+                    "pnp_bridge_adapter_config": {
+                        "bluetooth_address": "267541100483322",
+                        "blesensor_identity" : "Ruuvi"
+                    }
+                },
+                {
+                  "pnp_bridge_component_name": "mqttdevice1",
+                  "pnp_bridge_adapter_id": "mqtt-pnp-interface",
+                  "pnp_bridge_adapter_config": {
+                      "mqtt_port": "1",
+                      "mqtt_server": "1.1.1.1",
+                      "mqtt_protocol": "json_rpc",
+                      "mqtt_identity": "json_rpc_1"
+                  }
+                }
+            ],
+            "pnp_bridge_adapter_global_configs": {
+                "modbus-pnp-interface": {
+                    "DL679": {
+                        "telemetry": {
+                            "co2": {
+                                "startAddress": "40001",
+                                "length": 1,
+                                "dataType": "integer",
+                                "defaultFrequency": 5000,
+                                "conversionCoefficient": 1
+                            },
+                            "temperature": {
+                                "startAddress": "40003",
+                                "length": 1,
+                                "dataType": "decimal",
+                                "defaultFrequency": 5000,
+                                "conversionCoefficient": 0.01
+                            }
+                        },
+                        "properties": {
+                            "firmwareVersion": {
+                                "startAddress": "40482",
+                                "length": 1,
+                                "dataType": "hexstring",
+                                "defaultFrequency": 60000,
+                                "conversionCoefficient": 1,
+                                "access": 1
+                            },
+                            "modelName": {
+                                "startAddress": "40483",
+                                "length": 2,
+                                "dataType": "string",
+                                "defaultFrequency": 60000,
+                                "conversionCoefficient": 1,
+                                "access": 1
+                            },
+                            "alarmStatus_co2": {
+                                "startAddress": "00305",
+                                "length": 1,
+                                "dataType": "boolean",
+                                "defaultFrequency": 1000,
+                                "conversionCoefficient": 1,
+                                "access": 1
+                            },
+                            "alarmThreshold_co2": {
+                                "startAddress": "40225",
+                                "length": 1,
+                                "dataType": "integer",
+                                "defaultFrequency": 30000,
+                                "conversionCoefficient": 1,
+                                "access": 2
+                            }
+                        },
+                        "commands": {
+                            "clearAlarm_co2": {
+                                "startAddress": "00305",
+                                "length": 1,
+                                "dataType": "flag",
+                                "conversionCoefficient": 1
+                            }
+                        }
+                    }
+                },
+                "core-device-health": {
+                    "device_interface_classes": [
+                        "A5DCBF10-6530-11D2-901F-00C04FB951ED"
+                      ]
+                },
+                "bluetooth-sensor-pnp-adapter": {
+                    "Ruuvi" : {
+                        "company_id": "0x499",
+                        "endianness": "big",
+                        "telemetry_descriptor": [
+                          {
+                            "telemetry_name": "humidity",
+                            "data_parse_type": "uint8",
+                            "data_offset": 1,
+                            "conversion_bias": 0,
+                            "conversion_coefficient": 0.5
+                          },
+                          {
+                            "telemetry_name": "temperature",
+                            "data_parse_type": "int8",
+                            "data_offset": 2,
+                            "conversion_bias": 0,
+                            "conversion_coefficient": 1.0
+                          },
+                          {
+                            "telemetry_name": "pressure",
+                            "data_parse_type": "int16",
+                            "data_offset": 4,
+                            "conversion_bias": 0,
+                            "conversion_coefficient": 1.0
+                          },
+                          {
+                            "telemetry_name": "acceleration_x",
+                            "data_parse_type": "int16",
+                            "data_offset": 6,
+                            "conversion_bias": 0,
+                            "conversion_coefficient": 0.00980665
+                          },
+                          {
+                            "telemetry_name": "acceleration_y",
+                            "data_parse_type": "int16",
+                            "data_offset": 8,
+                            "conversion_bias": 0,
+                            "conversion_coefficient": 0.00980665
+                          },
+                          {
+                            "telemetry_name": "acceleration_z",
+                            "data_parse_type": "int16",
+                            "data_offset": 10,
+                            "conversion_bias": 0,
+                            "conversion_coefficient": 0.00980665
+                          }
+                        ]
+                    }
+                },
+                "mqtt-pnp-interface": {
+                  "json_rpc_1": [
+                      {
+                          "type": "telemetry",
+                          "json_rpc_method": "inventory_summary",
+                          "name": "inventory_summary",
+                          "rx_topic": "rfid/controller/events"
+                      },
+                      {
+                          "type": "telemetry",
+                          "json_rpc_method": "inventory_event",
+                          "name": "inventory_event",
+                          "rx_topic": "rfid/controller/events"
+                      },
+                      {
+                          "type": "command",
+                          "json_rpc_method": "inventory_get_tag_info",
+                          "name": "inventory_get_tag_info",
+                          "tx_topic": "rfid/controller/command",
+                          "rx_topic": "rfid/controller/response"
+                      },
+                      {
+                          "type": "command",
+                          "name": "inventory_unload",
+                          "json_rpc_method": "inventory_unload",
+                          "tx_topic": "rfid/controller/command",
+                          "rx_topic": "rfid/controller/response"
+                      },
+                      {
+                          "type": "command",
+                          "name": "scheduler_set_run_state",
+                          "json_rpc_method": "scheduler_set_run_state",
+                          "tx_topic": "rfid/controller/command",
+                          "rx_topic": "rfid/controller/response"
+                      }
+                  ]
+              }
+            }
+          }
+      }
+    }
+  }
+}

--- a/pnpbridge/deployment.template.json
+++ b/pnpbridge/deployment.template.json
@@ -1,0 +1,92 @@
+{
+  "$schema-template": "2.0.0",
+  "modulesContent": {
+    "$edgeAgent": {
+      "properties.desired": {
+        "schemaVersion": "1.0",
+        "runtime": {
+          "type": "docker",
+          "settings": {
+            "minDockerVersion": "v1.25",
+            "loggingOptions": "",
+            "registryCredentials": {
+              "pnpbridge": {
+                "username": "$CONTAINER_REGISTRY_USERNAME_pnpbridge",
+                "password": "$CONTAINER_REGISTRY_PASSWORD_pnpbridge",
+                "address": "<ADD CONTAINER REGISTRY ADDRESS HERE>"
+              }
+            }
+          }
+        },
+        "systemModules": {
+          "edgeAgent": {
+            "type": "docker",
+            "settings": {
+              "image": "mcr.microsoft.com/azureiotedge-agent:1.0",
+              "createOptions": {}
+            }
+          },
+          "edgeHub": {
+            "type": "docker",
+            "status": "running",
+            "restartPolicy": "always",
+            "settings": {
+              "image": "mcr.microsoft.com/azureiotedge-hub:1.0",
+              "createOptions": {
+                "HostConfig": {
+                  "PortBindings": {
+                    "5671/tcp": [
+                      {
+                        "HostPort": "5671"
+                      }
+                    ],
+                    "8883/tcp": [
+                      {
+                        "HostPort": "8883"
+                      }
+                    ],
+                    "443/tcp": [
+                      {
+                        "HostPort": "443"
+                      }
+                    ]
+                  }
+                }
+              }
+            }
+          }
+        },
+        "modules": {
+          "ModulePnpBridge": {
+            "version": "1.0",
+            "type": "docker",
+            "status": "running",
+            "restartPolicy": "always",
+            "settings": {
+              "image": "<ADD MODULE IMAGE HERE>",
+              "createOptions": {}
+            }
+          }
+        }
+      }
+    },
+    "$edgeHub": {
+      "properties.desired": {
+        "schemaVersion": "1.0",
+        "routes": {
+          "ModulePnpBridgeToIoTHub": "FROM /messages/modules/ModulePnpBridge/outputs/* INTO $upstream"
+        },
+        "storeAndForwardConfiguration": {
+          "timeToLiveSecs": 7200
+        }
+      }
+    },
+    "ModulePnpBridge":{
+      "properties.desired": {
+        "PnpBridgeConfig": {
+          "<ADD PNP BRIDGE CONFIG HERE>"
+        }
+      }
+    }
+  }
+}

--- a/pnpbridge/module.json
+++ b/pnpbridge/module.json
@@ -1,0 +1,18 @@
+{
+  "$schema-version": "0.0.1",
+  "description": "",
+  "image": {
+    "repository": "<ADD CONTAINER IMAGE REPOSITORY HERE>",
+    "tag": {
+      "version": "<ADD TAG HERE>",
+      "platforms": {
+        "amd64": "./Dockerfile.amd64",
+        "amd64.debug": "./Dockerfile.amd64.debug",
+        "arm32v7": "./Dockerfile.arm32v7",
+        "arm64v8": "./Dockerfile.arm64v8"
+      }
+    },
+    "buildOptions": []
+  },
+  "language": "c"
+}

--- a/pnpbridge/src/adapters/samples/environmental_sensor/CMakeLists.txt
+++ b/pnpbridge/src/adapters/samples/environmental_sensor/CMakeLists.txt
@@ -28,7 +28,9 @@ add_definitions("-D_UNICODE")
 
 set(pnp_bridge_INC_FOLDER ${CMAKE_CURRENT_LIST_DIR}/../pnpbridge/inc CACHE INTERNAL "this is what needs to be included if using pnp_bridge lib" FORCE)
 set(pnp_bridge_common_pnp_inc ${CMAKE_CURRENT_LIST_DIR}/../pnpbridge/common CACHE INTERNAL "this is what needs to be included if using pnp_bridge lib" FORCE)
+set(AZUREIOT_INC_FOLDER "/usr/include/azureiot" "/usr/include/azureiot/inc")
 
+include_directories(${AZUREIOT_INC_FOLDER})
 include_directories(../../deps/azure-iot-sdk-c-pnp/deps/parson)
 include_directories(../../deps/azure-iot-sdk-c-pnp/c-utility/inc)
 include_directories(../../deps/azure-iot-sdk-c-pnp/c-utility/deps/azure-macro-utils-c/inc)
@@ -46,10 +48,10 @@ ENDIF(WIN32)
 
 add_definitions(-DPNP_LOGGING_ENABLED)
 
-# add_library(${PROJECT_NAME} STATIC 
-    # ${pnpbridge_adaptersample_c_files}
-    # ${pnpbridge_adaptersample_h_files}
-# )
+add_library(${PROJECT_NAME} STATIC 
+    ${pnpbridge_adaptersample_c_files}
+    ${pnpbridge_adaptersample_h_files}
+)
 
 set(pnp_bridge_common_libs
     aziotsharedutil
@@ -70,10 +72,10 @@ set(pnp_bridge_common_libs
     utpm
 )
 
-add_executable(${PROJECT_NAME}
-    ${pnpbridge_adaptersample_c_files}
-    ${pnpbridge_adaptersample_h_files}
-)
+# add_executable(${PROJECT_NAME}
+    # ${pnpbridge_adaptersample_c_files}
+    # ${pnpbridge_adaptersample_h_files}
+# )
 target_link_libraries(${PROJECT_NAME} ${pnp_bridge_common_libs})
 
 configure_file(./config.json config.json COPYONLY)

--- a/pnpbridge/src/adapters/samples/environmental_sensor/adapter_manifest_pnpbridge.c
+++ b/pnpbridge/src/adapters/samples/environmental_sensor/adapter_manifest_pnpbridge.c
@@ -4,10 +4,10 @@
 // Pnp Adapter headers
 #include <pnpadapter_api.h>
 
-extern PNP_ADAPTER EnvironmentSensorInterface;
+extern PNP_ADAPTER VirtualEnvironmentSensorSample;
 
 PPNP_ADAPTER PNP_ADAPTER_MANIFEST[] = {
-    &EnvironmentSensorInterface
+    &VirtualEnvironmentSensorSample
 };
 
 const int PnpAdapterCount = sizeof(PNP_ADAPTER_MANIFEST) / sizeof(PPNP_ADAPTER);

--- a/pnpbridge/src/adapters/samples/environmental_sensor/adapter_manifest_pnpbridge.c
+++ b/pnpbridge/src/adapters/samples/environmental_sensor/adapter_manifest_pnpbridge.c
@@ -2,7 +2,7 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 // Pnp Adapter headers
-#include <pnpbridge.h>
+#include <pnpadapter_api.h>
 
 extern PNP_ADAPTER EnvironmentSensorInterface;
 

--- a/pnpbridge/src/adapters/samples/environmental_sensor/environmental_sensor.c
+++ b/pnpbridge/src/adapters/samples/environmental_sensor/environmental_sensor.c
@@ -178,8 +178,7 @@ static void SampleEnvironmentalSensor_PropertyCallback(
 
 // Processes a property update, which the server initiated, for customer name.
 static void SampleEnvironmentalSensor_CustomerNameCallback(
-    PENVIRONMENT_SENSOR EnvironmentalSensor,
-    IOTHUB_DEVICE_CLIENT_HANDLE DeviceClient,
+    PNPBRIDGE_COMPONENT_HANDLE PnpComponentHandle,
     const char* PropertyName,
     JSON_Value* PropertyValue,
     int version)
@@ -191,6 +190,8 @@ static void SampleEnvironmentalSensor_CustomerNameCallback(
 
     LogInfo("Environmental Sensor Adapter:: CustomerName property invoked...");
     LogInfo("Environmental Sensor Adapter:: CustomerName data=<%.*s>", (int)PropertyValueLen, PropertyValueString);
+
+    PENVIRONMENT_SENSOR EnvironmentalSensor = PnpComponentHandleGetContext(PnpComponentHandle);
 
     if (EnvironmentalSensor->SensorState != NULL)
     {
@@ -219,11 +220,11 @@ static void SampleEnvironmentalSensor_CustomerNameCallback(
                 const char* jsonToSendStr = STRING_c_str(jsonToSend);
                 size_t jsonToSendStrLen = strlen(jsonToSendStr);
 
-                if ((iothubClientResult = IoTHubDeviceClient_SendReportedState(DeviceClient, (const unsigned char*)jsonToSendStr, jsonToSendStrLen,
+                if ((iothubClientResult = SampleEnvironmentalSensor_RouteReportedState(PnpComponentHandle, (const unsigned char*)jsonToSendStr, jsonToSendStrLen,
                                             SampleEnvironmentalSensor_PropertyCallback,
                                             (void*) EnvironmentalSensor->SensorState->customerName)) != IOTHUB_CLIENT_OK)
                 {
-                    LogError("Environmental Sensor Adapter:: IoTHubDeviceClient_SendReportedState for customer name failed, error=%d", iothubClientResult);
+                    LogError("Environmental Sensor Adapter:: SampleEnvironmentalSensor_RouteReportedState for customer name failed, error=%d", iothubClientResult);
                 }
                 else
                 {
@@ -250,8 +251,7 @@ static bool SampleEnvironmentalSensor_ValidateBrightness(
 
 // Process a property update for bright level.
 static void SampleEnvironmentalSensor_BrightnessCallback(
-    PENVIRONMENT_SENSOR EnvironmentalSensor,
-    IOTHUB_DEVICE_CLIENT_HANDLE DeviceClient,
+    PNPBRIDGE_COMPONENT_HANDLE PnpComponentHandle,
     const char* PropertyName,
     JSON_Value* PropertyValue,
     int version)
@@ -261,6 +261,8 @@ static void SampleEnvironmentalSensor_BrightnessCallback(
     char targetBrightnessString[32];
 
     LogInfo("Environmental Sensor Adapter:: Brightness property invoked...");
+
+    PENVIRONMENT_SENSOR EnvironmentalSensor = PnpComponentHandleGetContext(PnpComponentHandle);
 
     if (json_value_get_type(PropertyValue) != JSONNumber)
     {
@@ -289,11 +291,11 @@ static void SampleEnvironmentalSensor_BrightnessCallback(
             const char* jsonToSendStr = STRING_c_str(jsonToSend);
             size_t jsonToSendStrLen = strlen(jsonToSendStr);
 
-            if ((iothubClientResult = IoTHubDeviceClient_SendReportedState(DeviceClient, (const unsigned char*)jsonToSendStr, jsonToSendStrLen,
+            if ((iothubClientResult = SampleEnvironmentalSensor_RouteReportedState(PnpComponentHandle, (const unsigned char*)jsonToSendStr, jsonToSendStrLen,
                                         SampleEnvironmentalSensor_PropertyCallback,
                                         (void*) &EnvironmentalSensor->SensorState->brightness)) != IOTHUB_CLIENT_OK)
             {
-                LogError("Environmental Sensor Adapter:: IoTHubDeviceClient_SendReportedState for brightness failed, error=%d", iothubClientResult);
+                LogError("Environmental Sensor Adapter:: SampleEnvironmentalSensor_RouteReportedState for brightness failed, error=%d", iothubClientResult);
             }
             else
             {
@@ -305,9 +307,53 @@ static void SampleEnvironmentalSensor_BrightnessCallback(
     }
 }
 
+// Routes the reported property for device or module client
+IOTHUB_CLIENT_RESULT SampleEnvironmentalSensor_RouteReportedState(
+    PNPBRIDGE_COMPONENT_HANDLE PnpComponentHandle,
+    const unsigned char * ReportedState,
+    size_t Size,
+    IOTHUB_CLIENT_REPORTED_STATE_CALLBACK ReportedStateCallback,
+    void * UserContextCallback)
+{
+    IOTHUB_CLIENT_RESULT iothubClientResult = IOTHUB_CLIENT_OK;
+    PNP_BRIDGE_IOT_TYPE clientType = PnpComponentHandleGetIoTType(PnpComponentHandle);
+    if (clientType == PNP_BRIDGE_IOT_TYPE_DEVICE)
+    {
+        IOTHUB_DEVICE_CLIENT_HANDLE deviceHandle = PnpComponentHandleGetIotHubDeviceClient(PnpComponentHandle);
+        if ((iothubClientResult = IoTHubDeviceClient_SendReportedState(deviceHandle, ReportedState, Size,
+            ReportedStateCallback, UserContextCallback)) != IOTHUB_CLIENT_OK)
+        {
+            LogError("IoTHubDeviceClient_SendReportedState failed with error code %d", iothubClientResult);
+            goto exit;
+        }
+        else
+        {
+            LogInfo("IoTHubDeviceClient_SendReportedState succeeded");
+        }
+    }
+    else if(clientType == PNP_BRIDGE_IOT_TYPE_RUNTIME_MODULE)
+    {
+        IOTHUB_MODULE_CLIENT_HANDLE moduleHandle = PnpComponentHandleGetIotHubModuleClient(PnpComponentHandle);
+        if ((iothubClientResult = IoTHubModuleClient_SendReportedState(moduleHandle, ReportedState, Size,
+            ReportedStateCallback, UserContextCallback)) != IOTHUB_CLIENT_OK)
+        {
+            LogError("IoTHubModuleClient_SendReportedState failed with error code %d", iothubClientResult);
+            goto exit;
+        }
+        else
+        {
+            LogInfo("IoTHubModuleClient_SendReportedState succeeded");
+        }
+    }
+
+exit:
+    return iothubClientResult;
+}
+
+
 // Sends a reported property for device state of this simulated device.
 IOTHUB_CLIENT_RESULT SampleEnvironmentalSensor_ReportDeviceStateAsync(
-    IOTHUB_DEVICE_CLIENT_HANDLE DeviceClient,
+    PNPBRIDGE_COMPONENT_HANDLE PnpComponentHandle,
     const char * ComponentName)
 {
 
@@ -323,7 +369,7 @@ IOTHUB_CLIENT_RESULT SampleEnvironmentalSensor_ReportDeviceStateAsync(
         const char* jsonToSendStr = STRING_c_str(jsonToSend);
         size_t jsonToSendStrLen = strlen(jsonToSendStr);
 
-        if ((iothubClientResult = IoTHubDeviceClient_SendReportedState(DeviceClient, (const unsigned char*)jsonToSendStr, jsonToSendStrLen,
+        if ((iothubClientResult = SampleEnvironmentalSensor_RouteReportedState(PnpComponentHandle, (const unsigned char*)jsonToSendStr, jsonToSendStrLen,
             SampleEnvironmentalSensor_PropertyCallback, (void*)sampleDeviceStateProperty)) != IOTHUB_CLIENT_OK)
         {
             LogError("Environmental Sensor Adapter:: Unable to send reported state for property=%s, error=%d",
@@ -374,20 +420,18 @@ int SampleEnvironmentalSensor_ProcessCommandUpdate(
 // SampleEnvironmentalSensor_ProcessPropertyUpdate receives updated properties from the server.  This implementation
 // acts as a simple dispatcher to the functions to perform the actual processing.
 void SampleEnvironmentalSensor_ProcessPropertyUpdate(
-    PENVIRONMENT_SENSOR EnvironmentalSensor,
-    IOTHUB_DEVICE_CLIENT_HANDLE DeviceClient,
+    PNPBRIDGE_COMPONENT_HANDLE PnpComponentHandle,
     const char* PropertyName,
     JSON_Value* PropertyValue,
     int version)
 {
-
     if (strcmp(PropertyName, sampleEnvironmentalSensorPropertyCustomerName) == 0)
     {
-        SampleEnvironmentalSensor_CustomerNameCallback(EnvironmentalSensor, DeviceClient, PropertyName, PropertyValue, version);
+        SampleEnvironmentalSensor_CustomerNameCallback(PnpComponentHandle, PropertyName, PropertyValue, version);
     }
     else if (strcmp(PropertyName, sampleEnvironmentalSensorPropertyBrightness) == 0)
     {
-        SampleEnvironmentalSensor_BrightnessCallback(EnvironmentalSensor, DeviceClient, PropertyName, PropertyValue, version);
+        SampleEnvironmentalSensor_BrightnessCallback(PnpComponentHandle, PropertyName, PropertyValue, version);
     }
     else if (strcmp(PropertyName, sampleDeviceStateProperty) == 0)
     {
@@ -402,6 +446,48 @@ void SampleEnvironmentalSensor_ProcessPropertyUpdate(
         // If the property is not implemented by this interface, presently we only record a log message but do not have a mechanism to report back to the service
         LogError("Environmental Sensor Adapter:: Property name <%s> is not associated with this interface", PropertyName);
     }
+}
+
+// Routes the sending asynchronous events for device or module client
+IOTHUB_CLIENT_RESULT SampleEnvironmentalSensor_RouteSendEventAsync(
+        PNPBRIDGE_COMPONENT_HANDLE PnpComponentHandle,
+        IOTHUB_MESSAGE_HANDLE EventMessageHandle,
+        IOTHUB_CLIENT_EVENT_CONFIRMATION_CALLBACK EventConfirmationCallback,
+        void * UserContextCallback)
+{
+    IOTHUB_CLIENT_RESULT iothubClientResult = IOTHUB_CLIENT_OK;
+    PNP_BRIDGE_IOT_TYPE clientType = PnpComponentHandleGetIoTType(PnpComponentHandle);
+    if (clientType == PNP_BRIDGE_IOT_TYPE_DEVICE)
+    {
+        IOTHUB_DEVICE_CLIENT_HANDLE deviceHandle = PnpComponentHandleGetIotHubDeviceClient(PnpComponentHandle);
+        if ((iothubClientResult = IoTHubDeviceClient_SendEventAsync(deviceHandle, EventMessageHandle,
+            EventConfirmationCallback, UserContextCallback)) != IOTHUB_CLIENT_OK)
+        {
+            LogError("IoTHubDeviceClient_SendEventAsync failed with error code %d", iothubClientResult);
+            goto exit;
+        }
+        else
+        {
+            LogInfo("IoTHubDeviceClient_SendEventAsync succeeded");
+        }
+    }
+    else if(clientType == PNP_BRIDGE_IOT_TYPE_RUNTIME_MODULE)
+    {
+        IOTHUB_MODULE_CLIENT_HANDLE moduleHandle = PnpComponentHandleGetIotHubModuleClient(PnpComponentHandle);
+        if ((iothubClientResult = IoTHubModuleClient_SendEventAsync(moduleHandle, EventMessageHandle,
+            EventConfirmationCallback, UserContextCallback)) != IOTHUB_CLIENT_OK)
+        {
+            LogError("IoTHubModuleClient_SendEventAsync failed with error code %d", iothubClientResult);
+            goto exit;
+        }
+        else
+        {
+            LogInfo("IoTHubModuleClient_SendEventAsync succeeded");
+        }
+    }
+
+exit:
+    return iothubClientResult;
 }
 
 
@@ -430,10 +516,11 @@ static void SampleEnvironmentalSensor_TelemetryCallback(
 // so this sample will work on platforms without these sensors).
 //
 IOTHUB_CLIENT_RESULT SampleEnvironmentalSensor_SendTelemetryMessagesAsync(
-    PENVIRONMENT_SENSOR EnvironmentalSensor)
+    PNPBRIDGE_COMPONENT_HANDLE PnpComponentHandle)
 {
     IOTHUB_CLIENT_RESULT result = IOTHUB_CLIENT_OK;
     IOTHUB_MESSAGE_HANDLE messageHandle = NULL;
+    PENVIRONMENT_SENSOR device = PnpComponentHandleGetContext(PnpComponentHandle);
 
     float currentTemperature = 20.0f + ((float)rand() / RAND_MAX) * 15.0f;
     float currentHumidity = 60.0f + ((float)rand() / RAND_MAX) * 20.0f;
@@ -443,14 +530,14 @@ IOTHUB_CLIENT_RESULT SampleEnvironmentalSensor_SendTelemetryMessagesAsync(
             currentTemperature, SampleEnvironmentalSensor_HumidityTelemetry, currentHumidity);
 
 
-    if ((messageHandle = PnP_CreateTelemetryMessageHandle(EnvironmentalSensor->SensorState->componentName, currentMessage)) == NULL)
+    if ((messageHandle = PnP_CreateTelemetryMessageHandle(device->SensorState->componentName, currentMessage)) == NULL)
     {
         LogError("Environmental Sensor Adapter:: PnP_CreateTelemetryMessageHandle failed.");
     }
-    else if ((result = IoTHubDeviceClient_SendEventAsync(EnvironmentalSensor->DeviceClient, messageHandle,
-            SampleEnvironmentalSensor_TelemetryCallback, EnvironmentalSensor)) != IOTHUB_CLIENT_OK)
+    else if ((result = SampleEnvironmentalSensor_RouteSendEventAsync(PnpComponentHandle, messageHandle,
+            SampleEnvironmentalSensor_TelemetryCallback, device)) != IOTHUB_CLIENT_OK)
     {
-        LogError("Environmental Sensor Adapter:: IoTHubDeviceClient_SendEventAsync failed, error=%d", result);
+        LogError("Environmental Sensor Adapter:: SampleEnvironmentalSensor_RouteSendEventAsync failed, error=%d", result);
     }
 
     IoTHubMessage_Destroy(messageHandle);

--- a/pnpbridge/src/adapters/samples/environmental_sensor/environmental_sensor.c
+++ b/pnpbridge/src/adapters/samples/environmental_sensor/environmental_sensor.c
@@ -320,37 +320,19 @@ IOTHUB_CLIENT_RESULT SampleEnvironmentalSensor_RouteReportedState(
     void * UserContextCallback)
 {
     IOTHUB_CLIENT_RESULT iothubClientResult = IOTHUB_CLIENT_OK;
-    PNP_BRIDGE_IOT_TYPE clientType = PnpComponentHandleGetIoTType(PnpComponentHandle);
-    if (clientType == PNP_BRIDGE_IOT_TYPE_DEVICE)
-    {
-        IOTHUB_DEVICE_CLIENT_HANDLE deviceHandle = (ClientHandle != NULL) ?
-            (IOTHUB_DEVICE_CLIENT_HANDLE) ClientHandle : PnpComponentHandleGetIotHubDeviceClient(PnpComponentHandle);
 
-        if ((iothubClientResult = IoTHubDeviceClient_SendReportedState(deviceHandle, ReportedState, Size,
+    PNP_BRIDGE_CLIENT_HANDLE clientHandle = (ClientHandle != NULL) ?
+            (PNP_BRIDGE_CLIENT_HANDLE) ClientHandle : PnpComponentHandleGetClientHandle(PnpComponentHandle);
+
+    if ((iothubClientResult = PnpBridgeClient_SendReportedState(clientHandle, ReportedState, Size,
             ReportedStateCallback, UserContextCallback)) != IOTHUB_CLIENT_OK)
-        {
-            LogError("IoTHubDeviceClient_SendReportedState failed with error code %d", iothubClientResult);
-            goto exit;
-        }
-        else
-        {
-            LogInfo("IoTHubDeviceClient_SendReportedState succeeded");
-        }
-    }
-    else if(clientType == PNP_BRIDGE_IOT_TYPE_RUNTIME_MODULE)
     {
-        IOTHUB_MODULE_CLIENT_HANDLE moduleHandle = (ClientHandle != NULL) ?
-            (IOTHUB_MODULE_CLIENT_HANDLE)(ClientHandle) : PnpComponentHandleGetIotHubModuleClient(PnpComponentHandle);
-        if ((iothubClientResult = IoTHubModuleClient_SendReportedState(moduleHandle, ReportedState, Size,
-            ReportedStateCallback, UserContextCallback)) != IOTHUB_CLIENT_OK)
-        {
-            LogError("IoTHubModuleClient_SendReportedState failed with error code %d", iothubClientResult);
-            goto exit;
-        }
-        else
-        {
-            LogInfo("IoTHubModuleClient_SendReportedState succeeded");
-        }
+        LogError("IoTHub client call to _SendReportedState failed with error code %d", iothubClientResult);
+        goto exit;
+    }
+    else
+    {
+        LogInfo("IoTHub client call to _SendReportedState succeeded");
     }
 
 exit:
@@ -464,34 +446,16 @@ IOTHUB_CLIENT_RESULT SampleEnvironmentalSensor_RouteSendEventAsync(
         void * UserContextCallback)
 {
     IOTHUB_CLIENT_RESULT iothubClientResult = IOTHUB_CLIENT_OK;
-    PNP_BRIDGE_IOT_TYPE clientType = PnpComponentHandleGetIoTType(PnpComponentHandle);
-    if (clientType == PNP_BRIDGE_IOT_TYPE_DEVICE)
-    {
-        IOTHUB_DEVICE_CLIENT_HANDLE deviceHandle = PnpComponentHandleGetIotHubDeviceClient(PnpComponentHandle);
-        if ((iothubClientResult = IoTHubDeviceClient_SendEventAsync(deviceHandle, EventMessageHandle,
+    PNP_BRIDGE_CLIENT_HANDLE clientHandle = PnpComponentHandleGetClientHandle(PnpComponentHandle);
+    if ((iothubClientResult = PnpBridgeClient_SendEventAsync(clientHandle, EventMessageHandle,
             EventConfirmationCallback, UserContextCallback)) != IOTHUB_CLIENT_OK)
-        {
-            LogError("IoTHubDeviceClient_SendEventAsync failed with error code %d", iothubClientResult);
-            goto exit;
-        }
-        else
-        {
-            LogInfo("IoTHubDeviceClient_SendEventAsync succeeded");
-        }
+    {
+        LogError("IoTHub client call to _SendEventAsync failed with error code %d", iothubClientResult);
+        goto exit;
     }
-    else if(clientType == PNP_BRIDGE_IOT_TYPE_RUNTIME_MODULE)
+    else
     {
-        IOTHUB_MODULE_CLIENT_HANDLE moduleHandle = PnpComponentHandleGetIotHubModuleClient(PnpComponentHandle);
-        if ((iothubClientResult = IoTHubModuleClient_SendEventAsync(moduleHandle, EventMessageHandle,
-            EventConfirmationCallback, UserContextCallback)) != IOTHUB_CLIENT_OK)
-        {
-            LogError("IoTHubModuleClient_SendEventAsync failed with error code %d", iothubClientResult);
-            goto exit;
-        }
-        else
-        {
-            LogInfo("IoTHubModuleClient_SendEventAsync succeeded");
-        }
+        LogInfo("IoTHub client call to _SendEventAsync succeeded");
     }
 
 exit:

--- a/pnpbridge/src/adapters/samples/environmental_sensor/environmental_sensor.h
+++ b/pnpbridge/src/adapters/samples/environmental_sensor/environmental_sensor.h
@@ -32,7 +32,6 @@ typedef struct _ENVIRONMENT_SENSOR {
     THREAD_HANDLE WorkerHandle;
     volatile bool ShuttingDown;
     PENVIRONMENTAL_SENSOR_STATE SensorState;
-    IOTHUB_DEVICE_CLIENT_HANDLE DeviceClient;
 } ENVIRONMENT_SENSOR, * PENVIRONMENT_SENSOR;
 
 #ifdef __cplusplus

--- a/pnpbridge/src/adapters/samples/environmental_sensor/environmental_sensor.h
+++ b/pnpbridge/src/adapters/samples/environmental_sensor/environmental_sensor.h
@@ -13,6 +13,7 @@
 #include "pnp_device_client.h"
 #include "pnp_dps.h"
 #include "pnp_protocol.h"
+#include "pnp_bridge_client.h"
 
 //
 // Application state associated with the particular component. In particular it contains 
@@ -32,8 +33,7 @@ typedef struct _ENVIRONMENT_SENSOR {
     THREAD_HANDLE WorkerHandle;
     volatile bool ShuttingDown;
     PENVIRONMENTAL_SENSOR_STATE SensorState;
-    IOTHUB_DEVICE_CLIENT_HANDLE DeviceClient;
-    IOTHUB_MODULE_CLIENT_HANDLE ModuleClient;
+    PNP_BRIDGE_CLIENT_HANDLE ClientHandle;
 } ENVIRONMENT_SENSOR, * PENVIRONMENT_SENSOR;
 
 #ifdef __cplusplus

--- a/pnpbridge/src/adapters/samples/environmental_sensor/environmental_sensor.h
+++ b/pnpbridge/src/adapters/samples/environmental_sensor/environmental_sensor.h
@@ -32,6 +32,8 @@ typedef struct _ENVIRONMENT_SENSOR {
     THREAD_HANDLE WorkerHandle;
     volatile bool ShuttingDown;
     PENVIRONMENTAL_SENSOR_STATE SensorState;
+    IOTHUB_DEVICE_CLIENT_HANDLE DeviceClient;
+    IOTHUB_MODULE_CLIENT_HANDLE ModuleClient;
 } ENVIRONMENT_SENSOR, * PENVIRONMENT_SENSOR;
 
 #ifdef __cplusplus
@@ -46,6 +48,7 @@ extern "C"
         PNPBRIDGE_COMPONENT_HANDLE PnpComponentHandle,
         const char * ComponentName);
     IOTHUB_CLIENT_RESULT SampleEnvironmentalSensor_RouteReportedState(
+        void * ClientHandle,
         PNPBRIDGE_COMPONENT_HANDLE PnpComponentHandle,
         const unsigned char * ReportedState,
         size_t Size,
@@ -58,10 +61,11 @@ extern "C"
         void * UserContextCallback
         );
     void SampleEnvironmentalSensor_ProcessPropertyUpdate(
-        PNPBRIDGE_COMPONENT_HANDLE PnpComponentHandle,
+        void * ClientHandle,
         const char* PropertyName,
         JSON_Value* PropertyValue,
-        int version);
+        int version,
+        PNPBRIDGE_COMPONENT_HANDLE PnpComponentHandle);
     int SampleEnvironmentalSensor_ProcessCommandUpdate(
         PENVIRONMENT_SENSOR EnvironmentalSensor,
         const char* CommandName,

--- a/pnpbridge/src/adapters/samples/environmental_sensor/environmental_sensor.h
+++ b/pnpbridge/src/adapters/samples/environmental_sensor/environmental_sensor.h
@@ -42,13 +42,24 @@ extern "C"
 
     // Sends  telemetry messages about current environment
     IOTHUB_CLIENT_RESULT SampleEnvironmentalSensor_SendTelemetryMessagesAsync(
-        PENVIRONMENT_SENSOR EnvironmentalSensor);
+        PNPBRIDGE_COMPONENT_HANDLE PnpComponentHandle);
     IOTHUB_CLIENT_RESULT SampleEnvironmentalSensor_ReportDeviceStateAsync(
-        IOTHUB_DEVICE_CLIENT_HANDLE DeviceClient,
+        PNPBRIDGE_COMPONENT_HANDLE PnpComponentHandle,
         const char * ComponentName);
+    IOTHUB_CLIENT_RESULT SampleEnvironmentalSensor_RouteReportedState(
+        PNPBRIDGE_COMPONENT_HANDLE PnpComponentHandle,
+        const unsigned char * ReportedState,
+        size_t Size,
+        IOTHUB_CLIENT_REPORTED_STATE_CALLBACK ReportedStateCallback,
+        void * UserContextCallback);
+    IOTHUB_CLIENT_RESULT SampleEnvironmentalSensor_RouteSendEventAsync(
+        PNPBRIDGE_COMPONENT_HANDLE PnpComponentHandle,
+        IOTHUB_MESSAGE_HANDLE EventMessageHandle,
+        IOTHUB_CLIENT_EVENT_CONFIRMATION_CALLBACK EventConfirmationCallback,
+        void * UserContextCallback
+        );
     void SampleEnvironmentalSensor_ProcessPropertyUpdate(
-        PENVIRONMENT_SENSOR EnvironmentalSensor,
-        IOTHUB_DEVICE_CLIENT_HANDLE DeviceClient,
+        PNPBRIDGE_COMPONENT_HANDLE PnpComponentHandle,
         const char* PropertyName,
         JSON_Value* PropertyValue,
         int version);

--- a/pnpbridge/src/adapters/samples/environmental_sensor/environmental_sensor_pnpbridge.c
+++ b/pnpbridge/src/adapters/samples/environmental_sensor/environmental_sensor_pnpbridge.c
@@ -34,14 +34,7 @@ IOTHUB_CLIENT_RESULT EnvironmentSensor_StartPnpComponent(
     PENVIRONMENT_SENSOR device = PnpComponentHandleGetContext(PnpComponentHandle);
 
     // Store client handle before starting Pnp component
-    if (PnpComponentHandleGetIoTType(PnpComponentHandle) == PNP_BRIDGE_IOT_TYPE_DEVICE)
-    {
-        device->DeviceClient = PnpComponentHandleGetIotHubDeviceClient(PnpComponentHandle);
-    }
-    else
-    {
-        device->ModuleClient = PnpComponentHandleGetIotHubModuleClient(PnpComponentHandle);
-    }
+    device->ClientHandle = PnpComponentHandleGetClientHandle(PnpComponentHandle);
 
     // Set shutdown state
     device->ShuttingDown = false;
@@ -178,7 +171,7 @@ exit:
     return result;
 }
 
-PNP_ADAPTER EnvironmentSensorInterface = {
+PNP_ADAPTER VirtualEnvironmentSensorSample = {
     .identity = "environment-sensor-sample-pnp-adapter",
     .createAdapter = EnvironmentSensor_CreatePnpAdapter,
     .createPnpComponent = EnvironmentSensor_CreatePnpComponent,

--- a/pnpbridge/src/adapters/samples/environmental_sensor/environmental_sensor_pnpbridge.h
+++ b/pnpbridge/src/adapters/samples/environmental_sensor/environmental_sensor_pnpbridge.h
@@ -7,7 +7,7 @@
 extern "C"
 {
 #endif
-#include <pnpbridge.h>
+#include <pnpadapter_api.h>
 
 #include "azure_c_shared_utility/azure_base32.h"
 #include "azure_c_shared_utility/gballoc.h"

--- a/pnpbridge/src/adapters/src/Camera/CameraIotPnpDevice.cpp
+++ b/pnpbridge/src/adapters/src/Camera/CameraIotPnpDevice.cpp
@@ -6,6 +6,7 @@
 #include <fstream>
 #include "CameraIotPnpDevice.h"
 #include <pnpbridge_common.h>
+#include <pnpadapter_api.h>
 #include <pnpbridge.h>
 
 #define ONE_SECOND_IN_100HNS        10000000    // 10,000,000 100hns in 1 second.

--- a/pnpbridge/src/adapters/src/Camera/CameraPnPBridgeInterface.cpp
+++ b/pnpbridge/src/adapters/src/Camera/CameraPnPBridgeInterface.cpp
@@ -21,7 +21,7 @@ IOTHUB_CLIENT_RESULT Camera_StartPnpComponent(
         return IOTHUB_CLIENT_ERROR;
     }
 
-    IOTHUB_DEVICE_CLIENT_HANDLE deviceHandle = PnpComponentHandleGetIotHubDeviceClient(PnpComponentHandle);
+    IOTHUB_DEVICE_CLIENT_HANDLE deviceHandle = (IOTHUB_DEVICE_CLIENT_HANDLE) PnpComponentHandleGetClientHandle(PnpComponentHandle);
     cameraDevice->SetIotHubDeviceClientHandle(deviceHandle);
 
     if (cameraDevice)

--- a/pnpbridge/src/adapters/src/Camera/CameraPnPBridgeInterface.h
+++ b/pnpbridge/src/adapters/src/Camera/CameraPnPBridgeInterface.h
@@ -8,7 +8,7 @@ extern "C"
 {
 #endif
 
-#include <PnpBridge.h>
+#include <pnpadapter_api.h>
 
 extern PNP_ADAPTER CameraPnpInterface;
 

--- a/pnpbridge/src/adapters/src/Camera/NetworkCameraIotPnpDevice.cpp
+++ b/pnpbridge/src/adapters/src/Camera/NetworkCameraIotPnpDevice.cpp
@@ -6,7 +6,7 @@
 #include "util.h"
 #include <fstream>
 #include <pnpbridge_common.h>
-#include <pnpbridge.h>
+#include <pnpadapter_api.h>
 
 NetworkCameraIotPnpDevice::NetworkCameraIotPnpDevice(std::wstring& deviceName, std::string& componentName)
     : CameraIotPnpDevice(deviceName, componentName)

--- a/pnpbridge/src/adapters/src/Camera/pch.h
+++ b/pnpbridge/src/adapters/src/Camera/pch.h
@@ -33,7 +33,7 @@ using namespace Microsoft::WRL;
 using namespace Microsoft::WRL::Wrappers;
 
 // PnpBridge headers.
-#include <PnpBridge.h>
+#include <pnpadapter_api.h>
 
 // IOT Hub Headers
 #include <iothub.h>

--- a/pnpbridge/src/adapters/src/bluetooth_sensor/BluetoothSensorDeviceAdapter.h
+++ b/pnpbridge/src/adapters/src/bluetooth_sensor/BluetoothSensorDeviceAdapter.h
@@ -6,7 +6,7 @@
 #include <memory>
 #include <string>
 
-#include <pnpbridge.h>
+#include <pnpadapter_api.h>
 
 #include "InterfaceDescriptor.h"
 

--- a/pnpbridge/src/adapters/src/bluetooth_sensor/BluetoothSensorDeviceAdapterBase.cpp
+++ b/pnpbridge/src/adapters/src/bluetooth_sensor/BluetoothSensorDeviceAdapterBase.cpp
@@ -80,7 +80,7 @@ void BluetoothSensorDeviceAdapterBase::OnInterfaceRegisteredCallback(
     IOTHUB_CLIENT_RESULT interfaceStatus,
     void* /* userInterfaceContext */)
 {
-    if (PNPBRIDGE_SUCCESS(interfaceStatus))
+    if ((IOTHUB_CLIENT_OK == interfaceStatus))
     {
         LogInfo("Bluetooth sensor interface successfully registered.");
     }

--- a/pnpbridge/src/adapters/src/bluetooth_sensor/BluetoothSensorPnPBridgeInterface.cpp
+++ b/pnpbridge/src/adapters/src/bluetooth_sensor/BluetoothSensorPnPBridgeInterface.cpp
@@ -6,7 +6,7 @@
 
 #include <azure_c_shared_utility/xlogging.h>
 #include <azure_c_shared_utility/const_defines.h>
-#include <pnpbridge.h>
+#include <pnpadapter_api.h>
 #include <parson.h>
 
 #include "InterfaceDescriptor.h"

--- a/pnpbridge/src/adapters/src/bluetooth_sensor/BluetoothSensorPnPBridgeInterface.cpp
+++ b/pnpbridge/src/adapters/src/bluetooth_sensor/BluetoothSensorPnPBridgeInterface.cpp
@@ -31,7 +31,7 @@ IOTHUB_CLIENT_RESULT BluetoothSensor_StartPnpComponent(
         return IOTHUB_CLIENT_ERROR;
     }
     
-    IOTHUB_DEVICE_CLIENT_HANDLE deviceHandle = PnpComponentHandleGetIotHubDeviceClient(PnpComponentHandle);
+    IOTHUB_DEVICE_CLIENT_HANDLE deviceHandle = (IOTHUB_DEVICE_CLIENT_HANDLE) PnpComponentHandleGetClientHandle(PnpComponentHandle);
     deviceAdapter->SetIotHubDeviceClientHandle(deviceHandle);
 
     try

--- a/pnpbridge/src/adapters/src/core_device_health/core_device_health.c
+++ b/pnpbridge/src/adapters/src/core_device_health/core_device_health.c
@@ -601,7 +601,7 @@ IOTHUB_CLIENT_RESULT CoreDevice_StartPnpComponent(
         LogError("Device context is null, unable to start component");
         return IOTHUB_CLIENT_ERROR;
     }
-    IOTHUB_DEVICE_CLIENT_HANDLE deviceHandle = PnpComponentHandleGetIotHubDeviceClient(PnpComponentHandle);
+    IOTHUB_DEVICE_CLIENT_HANDLE deviceHandle = (IOTHUB_DEVICE_CLIENT_HANDLE) PnpComponentHandleGetClientHandle(PnpComponentHandle);
     device->DeviceClient = deviceHandle;
     device->TelemetryStarted = true;
     return CoreDevice_SendConnectionEventAsync(device, "DeviceStatus", "Connected");

--- a/pnpbridge/src/adapters/src/core_device_health/core_device_health.c
+++ b/pnpbridge/src/adapters/src/core_device_health/core_device_health.c
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-#include <PnpBridge.h>
+#include <pnpadapter_api.h>
 #include <windows.h>
 #include <cfgmgr32.h>
 #include <initguid.h>
@@ -359,7 +359,7 @@ static void CoreDevice_InterfaceRegisteredCallback(
     void* userInterfaceContext)
 {
     UNREFERENCED_PARAMETER(userInterfaceContext);
-    if (PNPBRIDGE_SUCCESS(dtInterfaceStatus))
+    if (IOTHUB_CLIENT_OK == dtInterfaceStatus)
     {
         LogInfo("Core Device Health: Interface registered.");
     }

--- a/pnpbridge/src/adapters/src/modbus_pnp/ModbusCapability.c
+++ b/pnpbridge/src/adapters/src/modbus_pnp/ModbusCapability.c
@@ -155,7 +155,7 @@ void ModbusPnp_PropertyHandler(
     capContext->connectionType = modbusDevice->DeviceConfig->ConnectionType;
     capContext->hLock= modbusDevice->hConnectionLock;
     capContext->deviceClient = modbusDevice->DeviceClient;
-    capContext->moduleClient = modbusDevice->DeviceClient;
+    capContext->moduleClient = modbusDevice->ModuleClient;
     capContext->clientType = modbusDevice->ClientType;
     capContext->componentName = modbusDevice->ComponentName;
 
@@ -325,7 +325,7 @@ ModbusPnp_ReportTelemetry(
              ((result = IoTHubModuleClient_SendEventAsync(CapabilityContext->moduleClient, messageHandle,
             ModbusPnp_ReportTelemetryCallback, (void*) TelemetryName)) != IOTHUB_CLIENT_OK))
     {
-        LogError("Modbus Adapter: IoTHubDeviceClient_SendEventAsync failed for device, error=%d", result);
+        LogError("Modbus Adapter: IoTHubModuleClient_SendEventAsync failed for device, error=%d", result);
     }
 
     IoTHubMessage_Destroy(messageHandle);

--- a/pnpbridge/src/adapters/src/modbus_pnp/ModbusCapability.h
+++ b/pnpbridge/src/adapters/src/modbus_pnp/ModbusCapability.h
@@ -68,8 +68,7 @@ typedef struct CapabilityContext {
     HANDLE hDevice;
     LOCK_HANDLE hLock;
     MODBUS_CONNECTION_TYPE connectionType;
-    IOTHUB_DEVICE_CLIENT_HANDLE deviceClient;
-    IOTHUB_MODULE_CLIENT_HANDLE moduleClient;
+    PNP_BRIDGE_CLIENT_HANDLE clientHandle;
     PNP_BRIDGE_IOT_TYPE clientType;
     char * componentName;
 }CapabilityContext;

--- a/pnpbridge/src/adapters/src/modbus_pnp/ModbusCapability.h
+++ b/pnpbridge/src/adapters/src/modbus_pnp/ModbusCapability.h
@@ -17,7 +17,7 @@ extern "C"
     typedef int HANDLE;
 #endif
 
-#include <pnpbridge.h>
+#include <pnpadapter_api.h>
 #include "azure_c_shared_utility/lock.h"
 #include "ModbusConnection/ModbusConnectionHelper.h"
 
@@ -69,6 +69,8 @@ typedef struct CapabilityContext {
     LOCK_HANDLE hLock;
     MODBUS_CONNECTION_TYPE connectionType;
     IOTHUB_DEVICE_CLIENT_HANDLE deviceClient;
+    IOTHUB_MODULE_CLIENT_HANDLE moduleClient;
+    PNP_BRIDGE_IOT_TYPE clientType;
     char * componentName;
 }CapabilityContext;
 

--- a/pnpbridge/src/adapters/src/modbus_pnp/ModbusCapability.h
+++ b/pnpbridge/src/adapters/src/modbus_pnp/ModbusCapability.h
@@ -28,7 +28,7 @@ typedef enum ModbusAccessType
 } ModbusAccessType;
 
 typedef struct ModbusTelemetry {
-    const char*  Name;
+    char*  Name;
     const char*  StartAddress;
     uint16_t Length;
     ModbusDataType  DataType;
@@ -41,7 +41,7 @@ typedef struct ModbusTelemetry {
 typedef void(*MODBUS_TELEMETRY_POLLING_TASK)(ModbusTelemetry* userContextCallback);
 
 typedef struct ModbusProperty {
-    const char*  Name;
+    char*  Name;
     const char*  StartAddress;
     uint16_t Length;
     ModbusDataType  DataType;
@@ -54,7 +54,7 @@ typedef struct ModbusProperty {
 } ModbusProperty, *PModbusProperty;
 
 typedef struct ModbusCommand {
-    const char*  Name;
+    char*  Name;
     const char*  StartAddress;
     uint16_t Length;
     ModbusDataType  DataType;

--- a/pnpbridge/src/adapters/src/modbus_pnp/ModbusPnp.c
+++ b/pnpbridge/src/adapters/src/modbus_pnp/ModbusPnp.c
@@ -661,6 +661,18 @@ Modbus_StartPnpComponent(
         return IOTHUB_CLIENT_ERROR;
     }
 
+    // Assign client handle
+    if (deviceContext->ClientType == PNP_BRIDGE_IOT_TYPE_DEVICE)
+    {
+        deviceContext->DeviceClient = PnpComponentHandleGetIotHubDeviceClient(PnpComponentHandle);
+    }
+    else
+    {
+        deviceContext->ModuleClient = PnpComponentHandleGetIotHubModuleClient(PnpComponentHandle);
+    }
+
+    PnpComponentHandleSetContext(PnpComponentHandle, deviceContext);
+
     // Start polling all telemetry
     return ModbusPnp_StartPollingAllTelemetryProperty(deviceContext);
 }
@@ -874,12 +886,10 @@ Modbus_CreatePnpComponent(
     if (PnpComponentHandleGetIoTType(BridgeComponentHandle) == PNP_BRIDGE_IOT_TYPE_DEVICE)
     {
         deviceContext->ClientType = PNP_BRIDGE_IOT_TYPE_DEVICE;
-        deviceContext->DeviceClient = PnpComponentHandleGetIotHubDeviceClient(BridgeComponentHandle);
     }
     else
     {
         deviceContext->ClientType = PNP_BRIDGE_IOT_TYPE_RUNTIME_MODULE;
-        deviceContext->ModuleClient = PnpComponentHandleGetIotHubModuleClient(BridgeComponentHandle);
     }
 
     // Allocate and copy component name into device context

--- a/pnpbridge/src/adapters/src/modbus_pnp/ModbusPnp.c
+++ b/pnpbridge/src/adapters/src/modbus_pnp/ModbusPnp.c
@@ -662,14 +662,7 @@ Modbus_StartPnpComponent(
     }
 
     // Assign client handle
-    if (deviceContext->ClientType == PNP_BRIDGE_IOT_TYPE_DEVICE)
-    {
-        deviceContext->DeviceClient = PnpComponentHandleGetIotHubDeviceClient(PnpComponentHandle);
-    }
-    else
-    {
-        deviceContext->ModuleClient = PnpComponentHandleGetIotHubModuleClient(PnpComponentHandle);
-    }
+    deviceContext->ClientHandle = PnpComponentHandleGetClientHandle(PnpComponentHandle);
 
     PnpComponentHandleSetContext(PnpComponentHandle, deviceContext);
 

--- a/pnpbridge/src/adapters/src/modbus_pnp/ModbusPnp.c
+++ b/pnpbridge/src/adapters/src/modbus_pnp/ModbusPnp.c
@@ -66,18 +66,18 @@ ModbusDataType ToModbusDataTypeEnum(
 }
 
 IOTHUB_CLIENT_RESULT ModbusPnp_ParseInterfaceConfig(
-    ModbusInterfaceConfig* ModbusInterfaceConfig,
+    PModbusInterfaceConfig * ModbusInterfaceConfig,
     JSON_Object* ConfigObj)
 {
-    if (NULL == ModbusInterfaceConfig)
+    if (NULL == *ModbusInterfaceConfig)
     {
         LogError("Cannot populate interface config for modbus adapter.");
         return IOTHUB_CLIENT_INVALID_ARG;
     }
 
-    ModbusInterfaceConfig->Events = singlylinkedlist_create();
-    ModbusInterfaceConfig->Properties = singlylinkedlist_create();
-    ModbusInterfaceConfig->Commands = singlylinkedlist_create();
+    (*ModbusInterfaceConfig)->Events = singlylinkedlist_create();
+    (*ModbusInterfaceConfig)->Properties = singlylinkedlist_create();
+    (*ModbusInterfaceConfig)->Commands = singlylinkedlist_create();
 
     JSON_Object* telemetryList = json_object_dotget_object(ConfigObj, "telemetry");
     for (size_t i = 0; i < json_object_get_count(telemetryList); i++)
@@ -98,7 +98,7 @@ IOTHUB_CLIENT_RESULT ModbusPnp_ParseInterfaceConfig(
             return IOTHUB_CLIENT_ERROR;
         }
 
-        telemetry->Name = name;
+        mallocAndStrcpy_s(&telemetry->Name, name);
 
         telemetry->StartAddress = json_object_dotget_string(telemetryArgs, "startAddress");
         if (0 == telemetry->StartAddress)
@@ -140,7 +140,7 @@ IOTHUB_CLIENT_RESULT ModbusPnp_ParseInterfaceConfig(
             return IOTHUB_CLIENT_INVALID_ARG;
         }
 
-        singlylinkedlist_add(ModbusInterfaceConfig->Events, telemetry);
+        singlylinkedlist_add((*ModbusInterfaceConfig)->Events, telemetry);
     }
 
     JSON_Object* propertyList = json_object_dotget_object(ConfigObj, "properties");
@@ -162,7 +162,7 @@ IOTHUB_CLIENT_RESULT ModbusPnp_ParseInterfaceConfig(
             return IOTHUB_CLIENT_ERROR;
         }
 
-        property->Name = name;
+        mallocAndStrcpy_s(&property->Name, name);
 
         property->StartAddress = json_object_dotget_string(propertyArgs, "startAddress");
         if (0 == property->StartAddress)
@@ -212,7 +212,7 @@ IOTHUB_CLIENT_RESULT ModbusPnp_ParseInterfaceConfig(
             return IOTHUB_CLIENT_INVALID_ARG;
         }
 
-        singlylinkedlist_add(ModbusInterfaceConfig->Properties, property);
+        singlylinkedlist_add((*ModbusInterfaceConfig)->Properties, property);
     }
 
     JSON_Object* commandList = json_object_dotget_object(ConfigObj, "commands");
@@ -235,7 +235,7 @@ IOTHUB_CLIENT_RESULT ModbusPnp_ParseInterfaceConfig(
             return IOTHUB_CLIENT_ERROR;
         }
 
-        command->Name = name;
+        mallocAndStrcpy_s(&command->Name, name);
 
         command->StartAddress = json_object_dotget_string(commandArgs, "startAddress");
         if (0 == command->StartAddress)
@@ -271,7 +271,7 @@ IOTHUB_CLIENT_RESULT ModbusPnp_ParseInterfaceConfig(
             return IOTHUB_CLIENT_INVALID_ARG;
         }
 
-        singlylinkedlist_add(ModbusInterfaceConfig->Commands, command);
+        singlylinkedlist_add((*ModbusInterfaceConfig)->Commands, command);
     }
 
     return IOTHUB_CLIENT_OK;
@@ -576,6 +576,10 @@ void ModbusPnp_FreeTelemetryList(
     LIST_ITEM_HANDLE telemetryItem = singlylinkedlist_get_head_item(telemetryList);
     while (NULL != telemetryItem) {
         ModbusTelemetry* telemetry = (ModbusTelemetry*)singlylinkedlist_item_get_value(telemetryItem);
+        if (telemetry->Name)
+        {
+            free(telemetry->Name);
+        }
         free(telemetry);
         telemetryItem = singlylinkedlist_get_next_item(telemetryItem);
     }
@@ -591,6 +595,10 @@ void ModbusPnp_FreeCommandList(
     LIST_ITEM_HANDLE commandItem = singlylinkedlist_get_head_item(commandList);
     while (NULL != commandItem) {
         ModbusCommand* command = (ModbusCommand*)singlylinkedlist_item_get_value(commandItem);
+        if (command->Name)
+        {
+            free(command->Name);
+        }
         free(command);
         commandItem = singlylinkedlist_get_next_item(commandItem);
     }
@@ -606,6 +614,10 @@ void ModbusPnp_FreePropertyList(
     LIST_ITEM_HANDLE propertyItem = singlylinkedlist_get_head_item(propertyList);
     while (NULL != propertyItem) {
         ModbusProperty* property = (ModbusProperty*)singlylinkedlist_item_get_value(propertyItem);
+        if (property->Name)
+        {
+            free(property->Name);
+        }
         free(property);
         propertyItem = singlylinkedlist_get_next_item(propertyItem);
     }
@@ -724,7 +736,7 @@ IOTHUB_CLIENT_RESULT Modbus_CreatePnpAdapter(
 
         JSON_Object* interfaceConfigJson = json_object_get_object(AdapterGlobalConfig, modbusConfigIdentity);
 
-        if (IOTHUB_CLIENT_OK != ModbusPnp_ParseInterfaceConfig(interfaceConfig, interfaceConfigJson))
+        if (IOTHUB_CLIENT_OK != ModbusPnp_ParseInterfaceConfig(&interfaceConfig, interfaceConfigJson))
         {
             LogError("Could not parse interface config definition for %s", (char*)interfaceConfig->Id);
             result = IOTHUB_CLIENT_INVALID_ARG;

--- a/pnpbridge/src/adapters/src/modbus_pnp/ModbusPnp.h
+++ b/pnpbridge/src/adapters/src/modbus_pnp/ModbusPnp.h
@@ -8,7 +8,7 @@ extern "C"
 {
 #endif
 
-#include <pnpbridge.h>
+#include <pnpadapter_api.h>
 #include "azure_c_shared_utility/threadapi.h"
 #include "azure_c_shared_utility/singlylinkedlist.h"
 #include "azure_c_shared_utility/lock.h"
@@ -92,12 +92,14 @@ typedef int SOCKET;
         HANDLE hDevice;
         LOCK_HANDLE hConnectionLock;
         IOTHUB_DEVICE_CLIENT_HANDLE DeviceClient;
+        IOTHUB_MODULE_CLIENT_HANDLE ModuleClient;
         THREAD_HANDLE ModbusDeviceWorker;
 
         PModbusDeviceConfig DeviceConfig;
         PModbusInterfaceConfig InterfaceConfig;
         THREAD_HANDLE* PollingTasks;
         char * ComponentName;
+        PNP_BRIDGE_IOT_TYPE ClientType;
     } MODBUS_DEVICE_CONTEXT, *PMODBUS_DEVICE_CONTEXT;
 
     typedef struct _MODBUS_ADAPTER_CONTEXT {

--- a/pnpbridge/src/adapters/src/modbus_pnp/ModbusPnp.h
+++ b/pnpbridge/src/adapters/src/modbus_pnp/ModbusPnp.h
@@ -91,8 +91,7 @@ typedef int SOCKET;
     typedef struct _MODBUS_DEVICE_CONTEXT {
         HANDLE hDevice;
         LOCK_HANDLE hConnectionLock;
-        IOTHUB_DEVICE_CLIENT_HANDLE DeviceClient;
-        IOTHUB_MODULE_CLIENT_HANDLE ModuleClient;
+        PNP_BRIDGE_CLIENT_HANDLE ClientHandle;
         THREAD_HANDLE ModbusDeviceWorker;
 
         PModbusDeviceConfig DeviceConfig;

--- a/pnpbridge/src/adapters/src/mqtt_pnp/json_rpc_protocol_handler.cpp
+++ b/pnpbridge/src/adapters/src/mqtt_pnp/json_rpc_protocol_handler.cpp
@@ -28,7 +28,7 @@ JsonRpcProtocolHandler::JsonRpcProtocolHandler(
         const std::string& ComponentName) :
         s_ComponentName(ComponentName),
         s_TelemetryStarted(false),
-        s_DeviceClient(NULL)
+        s_ClientHandle(NULL)
 {
 
 }
@@ -229,17 +229,10 @@ JsonRpcProtocolHandler::RpcNotificationCallback(
             {
                 LogError("Mqtt Pnp Component: PnP_CreateTelemetryMessageHandle failed.");
             }
-            else if ((ph->s_ClientType ==  PNP_BRIDGE_IOT_TYPE_DEVICE) &&
-                    ((result = IoTHubDeviceClient_SendEventAsync(ph->s_DeviceClient, messageHandle,
-                    NULL, NULL)) != IOTHUB_CLIENT_OK))
+            else if (((result = PnpBridgeClient_SendEventAsync(ph->s_ClientHandle, messageHandle,
+                        NULL, NULL)) != IOTHUB_CLIENT_OK))
             {
-                LogError("Mqtt Pnp Component: IoTHubDeviceClient_SendEventAsync failed for device, error=%d", result);
-            }
-            else if ((ph->s_ClientType ==  PNP_BRIDGE_IOT_TYPE_RUNTIME_MODULE) &&
-                    ((result = IoTHubModuleClient_SendEventAsync(ph->s_ModuleClient, messageHandle,
-                    NULL, NULL)) != IOTHUB_CLIENT_OK))
-            {
-                LogError("Mqtt Pnp Component: IoTHubModuleClient_SendEventAsync failed for module, error=%d", result);
+                LogError("Mqtt Pnp Component: IoTHub's client call to _SendEventAsync failed, error=%d", result);
             }
             else
             {
@@ -264,15 +257,14 @@ void JsonRpcProtocolHandler::SetIotHubClientHandle(
     PNPBRIDGE_COMPONENT_HANDLE PnpComponentHandle)
 {
     // Assign client handle
+    s_ClientHandle = PnpComponentHandleGetClientHandle(PnpComponentHandle);
     if (PnpComponentHandleGetIoTType(PnpComponentHandle) == PNP_BRIDGE_IOT_TYPE_DEVICE)
     {
         s_ClientType = PNP_BRIDGE_IOT_TYPE_DEVICE;
-        s_DeviceClient = PnpComponentHandleGetIotHubDeviceClient(PnpComponentHandle);
     }
     else
     {
         s_ClientType = PNP_BRIDGE_IOT_TYPE_RUNTIME_MODULE;
-        s_ModuleClient = PnpComponentHandleGetIotHubModuleClient(PnpComponentHandle);
     }
 }
 

--- a/pnpbridge/src/adapters/src/mqtt_pnp/json_rpc_protocol_handler.hpp
+++ b/pnpbridge/src/adapters/src/mqtt_pnp/json_rpc_protocol_handler.hpp
@@ -40,8 +40,8 @@ public:
     );
 
     void
-    SetIotHubDeviceClientHandle(
-        IOTHUB_DEVICE_CLIENT_HANDLE DeviceClientHandle
+    SetIotHubClientHandle(
+        PNPBRIDGE_COMPONENT_HANDLE PnpComponentHandle
     );
 
     void 
@@ -56,6 +56,8 @@ private:
     JsonRpc*                            s_JsonRpc = nullptr;
     std::string                         s_ComponentName;
     IOTHUB_DEVICE_CLIENT_HANDLE         s_DeviceClient;
+    IOTHUB_MODULE_CLIENT_HANDLE         s_ModuleClient;
+    PNP_BRIDGE_IOT_TYPE                 s_ClientType;
     bool                                s_TelemetryStarted;
 
     static

--- a/pnpbridge/src/adapters/src/mqtt_pnp/json_rpc_protocol_handler.hpp
+++ b/pnpbridge/src/adapters/src/mqtt_pnp/json_rpc_protocol_handler.hpp
@@ -55,8 +55,7 @@ private:
                                         s_Commands;
     JsonRpc*                            s_JsonRpc = nullptr;
     std::string                         s_ComponentName;
-    IOTHUB_DEVICE_CLIENT_HANDLE         s_DeviceClient;
-    IOTHUB_MODULE_CLIENT_HANDLE         s_ModuleClient;
+    PNP_BRIDGE_CLIENT_HANDLE            s_ClientHandle;
     PNP_BRIDGE_IOT_TYPE                 s_ClientType;
     bool                                s_TelemetryStarted;
 

--- a/pnpbridge/src/adapters/src/mqtt_pnp/mqtt_pnp.cpp
+++ b/pnpbridge/src/adapters/src/mqtt_pnp/mqtt_pnp.cpp
@@ -166,7 +166,6 @@ MqttPnp_CreatePnpComponent(
     }
 
     context->s_ProtocolHandler->Initialize(&context->s_ConnectionManager, adapterConfig);
-    context->s_ProtocolHandler->SetIotHubClientHandle(PnpComponentHandle);
 
     PnpComponentHandleSetContext(PnpComponentHandle, context);
     PnpComponentHandleSetPropertyUpdateCallback(PnpComponentHandle, MqttPnp_OnPnpPropertyCallback);
@@ -215,6 +214,8 @@ MqttPnp_StartPnpComponent(
     LogInfo("Starting the PnP interface: %p", PnpComponentHandle);
 
     MqttPnpInstance* context = static_cast<MqttPnpInstance*>(PnpComponentHandleGetContext(PnpComponentHandle));
+
+    context->s_ProtocolHandler->SetIotHubClientHandle(PnpComponentHandle);
 
     if (context)
     {

--- a/pnpbridge/src/adapters/src/mqtt_pnp/mqtt_pnp.cpp
+++ b/pnpbridge/src/adapters/src/mqtt_pnp/mqtt_pnp.cpp
@@ -166,6 +166,7 @@ MqttPnp_CreatePnpComponent(
     }
 
     context->s_ProtocolHandler->Initialize(&context->s_ConnectionManager, adapterConfig);
+    context->s_ProtocolHandler->SetIotHubClientHandle(PnpComponentHandle);
 
     PnpComponentHandleSetContext(PnpComponentHandle, context);
     PnpComponentHandleSetPropertyUpdateCallback(PnpComponentHandle, MqttPnp_OnPnpPropertyCallback);
@@ -217,8 +218,6 @@ MqttPnp_StartPnpComponent(
 
     if (context)
     {
-        IOTHUB_DEVICE_CLIENT_HANDLE deviceHandle = PnpComponentHandleGetIotHubDeviceClient(PnpComponentHandle);
-        context->s_ProtocolHandler->SetIotHubDeviceClientHandle(deviceHandle);
         context->s_ProtocolHandler->StartTelemetry();
     }
 

--- a/pnpbridge/src/adapters/src/mqtt_pnp/mqtt_pnp.hpp
+++ b/pnpbridge/src/adapters/src/mqtt_pnp/mqtt_pnp.hpp
@@ -3,7 +3,8 @@
 #pragma once
 
 #include "mqtt_protocol_handler.hpp"
-#include <pnpbridge.h>
+#include <pnpadapter_api.h>
+#include <nosal.h>
 
 #ifdef __cplusplus
 extern "C" {

--- a/pnpbridge/src/adapters/src/mqtt_pnp/mqtt_protocol_handler.hpp
+++ b/pnpbridge/src/adapters/src/mqtt_pnp/mqtt_protocol_handler.hpp
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 #pragma once
-#include "pnpbridge.h"
+#include "pnpadapter_api.h"
 class MqttProtocolHandler {
 public:
     virtual
@@ -21,8 +21,8 @@ public:
     ) = 0;
 
     virtual
-    void SetIotHubDeviceClientHandle(
-        IOTHUB_DEVICE_CLIENT_HANDLE DeviceClientHandle) = 0;
+    void SetIotHubClientHandle(
+        PNPBRIDGE_COMPONENT_HANDLE PnpComponentHandle) = 0;
 
     virtual
     void OnPnpPropertyCallback(

--- a/pnpbridge/src/adapters/src/serial_pnp/serial_pnp.c
+++ b/pnpbridge/src/adapters/src/serial_pnp/serial_pnp.c
@@ -1,6 +1,6 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
-#include <pnpbridge.h>
+#include <pnpadapter_api.h>
 
 #include "azure_c_shared_utility/azure_base32.h"
 #include "azure_c_shared_utility/gballoc.h"
@@ -1277,10 +1277,17 @@ IOTHUB_CLIENT_RESULT SerialPnp_SendEventAsync(
     {
         LogError("Serial Pnp Adapter: PnP_CreateTelemetryMessageHandle failed.");
     }
-    else if ((result = IoTHubDeviceClient_SendEventAsync(DeviceContext->DeviceClient, messageHandle,
-            SerialPnp_SendEventCallback, (void*)TelemetryName)) != IOTHUB_CLIENT_OK)
+    else if ((DeviceContext->ClientType == PNP_BRIDGE_IOT_TYPE_DEVICE) &&
+             ((result = IoTHubDeviceClient_SendEventAsync(DeviceContext->DeviceClient, messageHandle,
+            SerialPnp_SendEventCallback, (void*)TelemetryName)) != IOTHUB_CLIENT_OK))
     {
         LogError("Serial Pnp Adapter: IoTHubDeviceClient_SendEventAsync failed, error=%d", result);
+    }
+    else if ((DeviceContext->ClientType == PNP_BRIDGE_IOT_TYPE_RUNTIME_MODULE) &&
+             ((result = IoTHubModuleClient_SendEventAsync(DeviceContext->ModuleClient, messageHandle,
+            SerialPnp_SendEventCallback, (void*)TelemetryName)) != IOTHUB_CLIENT_OK))
+    {
+        LogError("Serial Pnp Adapter: IoTHubModuleClient_SendEventAsync failed, error=%d", result);
     }
 
     IoTHubMessage_Destroy(messageHandle);
@@ -1314,9 +1321,10 @@ static void SerialPnp_PropertyUpdateHandler(
     void* userContextCallback)
 {
     AZURE_UNREFERENCED_PARAMETER(version);
+    AZURE_UNREFERENCED_PARAMETER(userContextCallback);
     IOTHUB_CLIENT_RESULT iothubClientResult;
     PSERIAL_DEVICE_CONTEXT deviceContext = PnpComponentHandleGetContext(PnpComponentHandle);
-    IOTHUB_DEVICE_CLIENT_HANDLE deviceClient = (IOTHUB_DEVICE_CLIENT_HANDLE)userContextCallback;
+
     STRING_HANDLE jsonToSend = NULL;
     const char * PropertyValueString = json_value_get_string(PropertyValue);
     size_t PropertyValueLen = strlen(PropertyValueString);
@@ -1347,10 +1355,18 @@ static void SerialPnp_PropertyUpdateHandler(
                 const char* jsonToSendStr = STRING_c_str(jsonToSend);
                 size_t jsonToSendStrLen = strlen(jsonToSendStr);
 
-                if ((iothubClientResult = IoTHubDeviceClient_SendReportedState(deviceClient, (const unsigned char*)jsonToSendStr, jsonToSendStrLen,
-                    NULL, NULL)) != IOTHUB_CLIENT_OK)
+                if ((deviceContext->ClientType == PNP_BRIDGE_IOT_TYPE_DEVICE) && 
+                    ((iothubClientResult = IoTHubDeviceClient_SendReportedState(deviceContext->DeviceClient, (const unsigned char*)jsonToSendStr, jsonToSendStrLen,
+                    NULL, NULL)) != IOTHUB_CLIENT_OK))
                 {
-                    LogError("Serial Pnp Adapter: Unable to send reported state for property=%s, error=%d",
+                    LogError("Serial Pnp Adapter: Unable to send reported state for device property=%s, error=%d",
+                        PropertyName, iothubClientResult);
+                }
+                else  if ((deviceContext->ClientType == PNP_BRIDGE_IOT_TYPE_RUNTIME_MODULE) && 
+                    ((iothubClientResult = IoTHubModuleClient_SendReportedState(deviceContext->ModuleClient, (const unsigned char*)jsonToSendStr, jsonToSendStrLen,
+                    NULL, NULL)) != IOTHUB_CLIENT_OK))
+                {
+                    LogError("Serial Pnp Adapter: Unable to send reported state for module property=%s, error=%d",
                         PropertyName, iothubClientResult);
                 }
                 else
@@ -1427,9 +1443,6 @@ SerialPnp_StartPnpComponent(
         LogError("Device context is null, unable to start component");
         return IOTHUB_CLIENT_ERROR;
     }
-
-    IOTHUB_DEVICE_CLIENT_HANDLE deviceHandle = PnpComponentHandleGetIotHubDeviceClient(PnpComponentHandle);
-    deviceContext->DeviceClient = deviceHandle;
 
     // Start telemetry thread
     if (ThreadAPI_Create(&deviceContext->TelemetryWorkerHandle, SerialPnp_UartReceiver, deviceContext) != THREADAPI_OK) {
@@ -1712,6 +1725,18 @@ SerialPnp_CreatePnpComponent(
     if (THREADAPI_OK != ThreadAPI_Create(&deviceContext->SerialDeviceWorker, SerialPnp_ParseInterfaceConfig, deviceContext))
     {
         LogError("ThreadAPI_Create failed");
+    }
+
+    // Assign client handle
+    if (PnpComponentHandleGetIoTType(BridgeComponentHandle) == PNP_BRIDGE_IOT_TYPE_DEVICE)
+    {
+        deviceContext->ClientType = PNP_BRIDGE_IOT_TYPE_DEVICE;
+        deviceContext->DeviceClient = PnpComponentHandleGetIotHubDeviceClient(BridgeComponentHandle);
+    }
+    else
+    {
+        deviceContext->ClientType = PNP_BRIDGE_IOT_TYPE_RUNTIME_MODULE;
+        deviceContext->ModuleClient = PnpComponentHandleGetIotHubModuleClient(BridgeComponentHandle);
     }
 
     PnpComponentHandleSetContext(BridgeComponentHandle, deviceContext);

--- a/pnpbridge/src/adapters/src/serial_pnp/serial_pnp.h
+++ b/pnpbridge/src/adapters/src/serial_pnp/serial_pnp.h
@@ -108,8 +108,7 @@ extern "C"
 
     typedef struct _SERIAL_DEVICE_CONTEXT {
         HANDLE hSerial;
-        IOTHUB_DEVICE_CLIENT_HANDLE DeviceClient;
-        IOTHUB_MODULE_CLIENT_HANDLE ModuleClient;
+        PNP_BRIDGE_CLIENT_HANDLE ClientHandle;
         PNP_BRIDGE_IOT_TYPE ClientType;
         char * ComponentName;
         byte RxBuffer[MAX_BUFFER_SIZE]; // Temporary buffer that gets filled by the reading thread. TODO: maximum buffer size

--- a/pnpbridge/src/adapters/src/serial_pnp/serial_pnp.h
+++ b/pnpbridge/src/adapters/src/serial_pnp/serial_pnp.h
@@ -109,6 +109,8 @@ extern "C"
     typedef struct _SERIAL_DEVICE_CONTEXT {
         HANDLE hSerial;
         IOTHUB_DEVICE_CLIENT_HANDLE DeviceClient;
+        IOTHUB_MODULE_CLIENT_HANDLE ModuleClient;
+        PNP_BRIDGE_IOT_TYPE ClientType;
         char * ComponentName;
         byte RxBuffer[MAX_BUFFER_SIZE]; // Temporary buffer that gets filled by the reading thread. TODO: maximum buffer size
         byte* pbMainBuffer;             // pointer used to pass buffers back to the main thread

--- a/pnpbridge/src/adapters/src/shared/adapter_manifest.c
+++ b/pnpbridge/src/adapters/src/shared/adapter_manifest.c
@@ -7,7 +7,7 @@
 extern PNP_ADAPTER SerialPnpInterface;
 extern PNP_ADAPTER ModbusPnpInterface;
 extern PNP_ADAPTER MqttPnpInterface;
-extern PNP_ADAPTER EnvironmentSensorInterface;
+extern PNP_ADAPTER VirtualEnvironmentSensorSample;
 
 #ifdef WIN32
 
@@ -22,7 +22,7 @@ PPNP_ADAPTER PNP_ADAPTER_MANIFEST[] = {
     &ModbusPnpInterface,
     &MqttPnpInterface,
     &SerialPnpInterface,
-    &EnvironmentSensorInterface
+    &VirtualEnvironmentSensorSample
 };
 
 #else //WIN32
@@ -31,7 +31,7 @@ PPNP_ADAPTER PNP_ADAPTER_MANIFEST[] = {
     &ModbusPnpInterface,
     &MqttPnpInterface,
     &SerialPnpInterface,
-    &EnvironmentSensorInterface
+    &VirtualEnvironmentSensorSample
 };
 
 #endif

--- a/pnpbridge/src/adapters/src/shared/adapter_manifest.c
+++ b/pnpbridge/src/adapters/src/shared/adapter_manifest.c
@@ -2,11 +2,12 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 //Pnp Adapter headers
-#include <pnpbridge.h>
+#include <pnpadapter_api.h>
 
 extern PNP_ADAPTER SerialPnpInterface;
 extern PNP_ADAPTER ModbusPnpInterface;
 extern PNP_ADAPTER MqttPnpInterface;
+extern PNP_ADAPTER EnvironmentSensorInterface;
 
 #ifdef WIN32
 
@@ -20,7 +21,8 @@ PPNP_ADAPTER PNP_ADAPTER_MANIFEST[] = {
     &BluetoothSensorPnpInterface,
     &ModbusPnpInterface,
     &MqttPnpInterface,
-    &SerialPnpInterface
+    &SerialPnpInterface,
+    &EnvironmentSensorInterface
 };
 
 #else //WIN32
@@ -28,7 +30,8 @@ PPNP_ADAPTER PNP_ADAPTER_MANIFEST[] = {
 PPNP_ADAPTER PNP_ADAPTER_MANIFEST[] = {
     &ModbusPnpInterface,
     &MqttPnpInterface,
-    &SerialPnpInterface
+    &SerialPnpInterface,
+    &EnvironmentSensorInterface
 };
 
 #endif

--- a/pnpbridge/src/pnpbridge/CMakeLists.txt
+++ b/pnpbridge/src/pnpbridge/CMakeLists.txt
@@ -122,6 +122,12 @@ add_subdirectory(tests)
 add_subdirectory(samples)
 
 if(WIN32)
+
+else()
+add_subdirectory(module)
+endif()
+
+if(WIN32)
 # Ole32 (COM) is used by camera health monitoring adapter
 target_link_libraries(${PROJECT_NAME} ${pnp_bridge_common_libs} cfgmgr32 mfplat mfsensorgroup Ole32 runtimeobject)
 else()

--- a/pnpbridge/src/pnpbridge/CMakeLists.txt
+++ b/pnpbridge/src/pnpbridge/CMakeLists.txt
@@ -44,6 +44,7 @@ set(pnp_helper_h_core_files
     ./common/pnp_device_client.h
     ./common/pnp_dps.h
     ./common/pnp_protocol.h
+    ./common/pnp_bridge_client.h
 )
 
 # set(install_staticlibs

--- a/pnpbridge/src/pnpbridge/common/pnp_bridge_client.h
+++ b/pnpbridge/src/pnpbridge/common/pnp_bridge_client.h
@@ -1,0 +1,20 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+#ifndef PNP_BRIDGE_CLIENT_H
+#define PNP_BRIDGE_CLIENT_H
+
+#include "iothub_device_client.h"
+#include "iothub_module_client.h"
+
+#ifdef USE_MODULE_CLIENT
+    typedef IOTHUB_MODULE_CLIENT_HANDLE PNP_BRIDGE_CLIENT_HANDLE;
+    #define PnpBridgeClient_SendReportedState(iotHubClientHandle, reportedState, size, reportedStateCallback, userContextCallback) IoTHubModuleClient_SendReportedState(iotHubClientHandle, reportedState, size, reportedStateCallback, userContextCallback)
+    #define PnpBridgeClient_SendEventAsync(iotHubClientHandle, eventMessageHandle, eventConfirmationCallback, userContextCallback) IoTHubModuleClient_SendEventAsync(iotHubClientHandle, eventMessageHandle, eventConfirmationCallback, userContextCallback)
+#else
+    typedef IOTHUB_DEVICE_CLIENT_HANDLE PNP_BRIDGE_CLIENT_HANDLE;
+    #define PnpBridgeClient_SendReportedState(iotHubClientHandle, reportedState, size, reportedStateCallback, userContextCallback) IoTHubDeviceClient_SendReportedState(iotHubClientHandle, reportedState, size, reportedStateCallback, userContextCallback)
+    #define PnpBridgeClient_SendEventAsync(iotHubClientHandle, eventMessageHandle, eventConfirmationCallback, userContextCallback) IoTHubDeviceClient_SendEventAsync(iotHubClientHandle, eventMessageHandle, eventConfirmationCallback, userContextCallback)
+#endif
+
+#endif /* PNP_BRIDGE_CLIENT_H */

--- a/pnpbridge/src/pnpbridge/common/pnp_device_client.c
+++ b/pnpbridge/src/pnpbridge/common/pnp_device_client.c
@@ -7,6 +7,7 @@
 
 #include "iothub.h"
 #include "iothub_device_client.h"
+#include "iothub_module_client.h"
 #include "iothub_client_options.h"
 #include "iothubtransportmqtt.h"
 #include "pnp_device_client.h"
@@ -17,12 +18,12 @@
 #include "azure_c_shared_utility/threadapi.h"
 #include "azure_c_shared_utility/xlogging.h"
 
-#ifdef SET_TRUSTED_CERT_IN_SAMPLES
+#ifdef SET_TRUSTED_CERT
 // For devices that do not have (or want) an OS level trusted certificate store,
 // but instead bring in default trusted certificates from the Azure IoT C SDK.
 #include "azure_c_shared_utility/shared_util_options.h"
 #include "certs.h"
-#endif // SET_TRUSTED_CERT_IN_SAMPLES
+#endif // SET_TRUSTED_CERT
 
 //
 // AllocateDeviceClientHandle does the actual createHandle call, depending on the security type
@@ -86,7 +87,7 @@ IOTHUB_DEVICE_CLIENT_HANDLE PnP_CreateDeviceClientHandle(const PNP_DEVICE_CONFIG
         result = false;
     }
     // Optionall, set the callback function that processes device twin changes from the IoTHub, which is the channel that PnP Properties are 
-    // transferred over.  This will also automatically retrieve the full twin for the application on startup. 
+    // transferred over. This will also automatically retrieve the full twin for the application on startup.
     else if ((pnpDeviceConfiguration->deviceTwinCallback != NULL) && (iothubResult = IoTHubDeviceClient_SetDeviceTwinCallback(deviceHandle, pnpDeviceConfiguration->deviceTwinCallback, (void*)deviceHandle)) != IOTHUB_CLIENT_OK)
     {
         LogError("Unable to set device twin callback, error=%d", iothubResult);
@@ -98,7 +99,7 @@ IOTHUB_DEVICE_CLIENT_HANDLE PnP_CreateDeviceClientHandle(const PNP_DEVICE_CONFIG
         LogError("Unable to set auto Url encode option, error=%d", iothubResult);
         result = false;
     }
-#ifdef SET_TRUSTED_CERT_IN_SAMPLES
+#ifdef SET_TRUSTED_CERT
     // Setting the Trusted Certificate.  This is only necessary on systems without built in certificate stores.
     else if ((iothubResult = IoTHubDeviceClient_SetOption(deviceHandle, OPTION_TRUSTED_CERT, certificates)) != IOTHUB_CLIENT_OK)
     {
@@ -110,7 +111,7 @@ IOTHUB_DEVICE_CLIENT_HANDLE PnP_CreateDeviceClientHandle(const PNP_DEVICE_CONFIG
         LogError("Unable to set product info string option, error=%d", iothubResult);
         result = false;
     }
-#endif // SET_TRUSTED_CERT_IN_SAMPLES
+#endif // SET_TRUSTED_CERT
     else
     {
         result = true;
@@ -128,4 +129,108 @@ IOTHUB_DEVICE_CLIENT_HANDLE PnP_CreateDeviceClientHandle(const PNP_DEVICE_CONFIG
     }
 
     return deviceHandle;
+}
+
+
+//
+// AllocateModuleClientHandle does the actual createHandle call, depending on the security type
+//
+static IOTHUB_MODULE_CLIENT_HANDLE AllocateModuleClientHandle(const PNP_DEVICE_CONFIGURATION* pnpModuleConfiguration)
+{
+    IOTHUB_MODULE_CLIENT_HANDLE moduleClientHandle = NULL;
+
+    if (pnpModuleConfiguration->securityType == PNP_CONNECTION_SECURITY_TYPE_CONNECTION_STRING)
+    {
+        if ((moduleClientHandle = IoTHubModuleClient_CreateFromConnectionString(pnpModuleConfiguration->u.connectionString, MQTT_Protocol)) == NULL)
+        {
+            LogError("Failure creating IotHub module client. Hint: Check your connection string");
+        }
+    }
+
+    return moduleClientHandle;
+}
+
+IOTHUB_MODULE_CLIENT_HANDLE PnP_CreateModuleClientHandle(const PNP_DEVICE_CONFIGURATION* pnpModuleConfiguration)
+{
+    IOTHUB_MODULE_CLIENT_HANDLE moduleClientHandle = NULL;
+    IOTHUB_CLIENT_RESULT iothubResult;
+    bool urlAutoEncodeDecode = true;
+    int iothubInitResult;
+    bool result;
+
+    // Before invoking ANY IoT Hub or DPS functionality, IoTHub_Init must be invoked.
+    if ((iothubInitResult = IoTHub_Init()) != 0)
+    {
+        LogError("Failure to initialize module client, error=%d", iothubInitResult);
+        result = false;
+    }
+    else if ((moduleClientHandle = AllocateModuleClientHandle(pnpModuleConfiguration)) == NULL)
+    {
+        LogError("Unable to allocate moduleClientHandle");
+        result = false;
+    }
+    // Sets verbosity level
+    else if ((iothubResult = IoTHubModuleClient_SetOption(moduleClientHandle, OPTION_LOG_TRACE, &pnpModuleConfiguration->enableTracing)) != IOTHUB_CLIENT_OK)
+    {
+        LogError("Unable to set logging option for module client, error=%d", iothubResult);
+        result = false;
+    }
+    // Sets the name of ModelId for this PnP device.
+    // This *MUST* be set before the client is connected to IoTHub.  We do not automatically connect when the 
+    // handle is created, but will implicitly connect to subscribe for device method and device twin callbacks below.
+    else if ((iothubResult = IoTHubModuleClient_SetOption(moduleClientHandle, OPTION_MODEL_ID, pnpModuleConfiguration->modelId)) != IOTHUB_CLIENT_OK)
+    {
+        LogError("Unable to set the ModelID for module client, error=%d", iothubResult);
+        result = false;
+    }
+    // Optionally, set the callback function that processes incoming device methods, which is the channel PnP Commands are transferred over
+    else if ((pnpModuleConfiguration->deviceMethodCallback != NULL) && (iothubResult = IoTHubModuleClient_SetModuleMethodCallback(moduleClientHandle, pnpModuleConfiguration->deviceMethodCallback, NULL)) != IOTHUB_CLIENT_OK)
+    {
+        LogError("Unable to set device method callback for module client, error=%d", iothubResult);
+        result = false;
+    }
+    // Optionall, set the callback function that processes device twin changes from the IoTHub, which is the channel that PnP Properties are 
+    // transferred over.  This will also automatically retrieve the full twin for the application on startup. 
+    else if ((pnpModuleConfiguration->deviceTwinCallback != NULL) && (iothubResult = IoTHubModuleClient_SetModuleTwinCallback(moduleClientHandle, pnpModuleConfiguration->deviceTwinCallback, (void*)moduleClientHandle)) != IOTHUB_CLIENT_OK)
+    {
+        LogError("Unable to set device twin callback for module client, error=%d", iothubResult);
+        result = false;
+    }
+    // Enabling auto url encode will have the underlying SDK perform URL encoding operations automatically.
+    else if ((iothubResult = IoTHubModuleClient_SetOption(moduleClientHandle, OPTION_AUTO_URL_ENCODE_DECODE, &urlAutoEncodeDecode)) != IOTHUB_CLIENT_OK)
+    {
+        LogError("Unable to set auto Url encode option for module client, error=%d", iothubResult);
+        result = false;
+    }
+#ifdef SET_TRUSTED_CERT
+    // Setting the Trusted Certificate.  This is only necessary on systems without built in certificate stores.
+    else if ((iothubResult = IoTHubModuleClient_SetOption(moduleClientHandle, OPTION_TRUSTED_CERT, certificates)) != IOTHUB_CLIENT_OK)
+    {
+        LogError("Unable to set the trusted cert for module client, error=%d", iothubResult);
+        result = false;
+    }
+    else if ((iothubResult = IoTHubModuleClient_SetOption(moduleClientHandle, OPTION_PRODUCT_INFO, pnpModuleConfiguration->UserAgentString)) != IOTHUB_CLIENT_OK)
+    {
+        LogError("Unable to set product info string option for module client, error=%d", iothubResult);
+        result = false;
+    }
+#endif // SET_TRUSTED_CERT
+    else
+    {
+        result = true;
+    }
+
+    if ((result == false) && (moduleClientHandle != NULL))
+    {
+        IoTHubModuleClient_Destroy(moduleClientHandle);
+        moduleClientHandle = NULL;
+    }
+
+    if ((result == false) &&  (iothubInitResult == 0))
+    {
+        IoTHub_Deinit();
+    }
+
+    return moduleClientHandle;
+
 }

--- a/pnpbridge/src/pnpbridge/common/pnp_device_client.h
+++ b/pnpbridge/src/pnpbridge/common/pnp_device_client.h
@@ -5,6 +5,7 @@
 #define PNP_DEVICE_CLIENT_H
 
 #include "iothub_device_client.h"
+#include "iothub_module_client.h"
 
 //
 // Whether we're using a connection string or DPS provisioning for device credentials
@@ -61,5 +62,16 @@ typedef struct PNP_DEVICE_CONFIGURATION_TAG
 // NOTE: When using DPS based authentication, this function can *block* until DPS responds to the request or timeout.
 //
 IOTHUB_DEVICE_CLIENT_HANDLE PnP_CreateDeviceClientHandle(const PNP_DEVICE_CONFIGURATION* pnpDeviceConfiguration);
+
+
+//
+// PnP_CreateModuleClientHandle creates an IOTHUB_MODULE_CLIENT_HANDLE that will be ready to interact with PnP.
+// Beyond basic handle creation, it also sets the handle to the appropriate ModelId, optionally sets up callback functions
+// for Module Method and Module Twin callbacks (to process PnP Commands and Properties, respectively)
+// as well as some other basic maintenence on the handle. 
+//
+// NOTE: When using DPS based authentication, this function can *block* until DPS responds to the request or timeout.
+//
+IOTHUB_MODULE_CLIENT_HANDLE PnP_CreateModuleClientHandle(const PNP_DEVICE_CONFIGURATION* pnpModuleConfiguration);
 
 #endif /* PNP_DEVICE_CLIENT_H */

--- a/pnpbridge/src/pnpbridge/common/pnp_protocol.h
+++ b/pnpbridge/src/pnpbridge/common/pnp_protocol.h
@@ -37,6 +37,12 @@ extern "C"
 // 
 typedef void (*PnP_PropertyCallbackFunction)(const char* componentName, const char* propertyName, JSON_Value* propertyValue, int version, void* userContextCallback);
 
+
+//
+// PnP_ModuleConfigPropertyCallbackFunction defines the function prototype the application implements to receive a callback for Pnp Bridge module configuration
+// 
+typedef void (*PnP_ModuleConfigPropertyCallbackFunction)(JSON_Value* propertyValue);
+
 //
 // PnP_CreateReportedProperty returns JSON to report a property's value from the device.  This does NOT contain any metadata such as 
 // a result code or version.  It is used when sending properties that are NOT marked as <"writable": true> in the DTDL defining
@@ -79,6 +85,15 @@ IOTHUB_MESSAGE_HANDLE PnP_CreateTelemetryMessageHandle(const char* componentName
 // function for each property that it visits.
 // 
 bool PnP_ProcessTwinData(DEVICE_TWIN_UPDATE_STATE updateState, const unsigned char* payload, size_t size, const char** componentsInModel, size_t numComponentsInModel, PnP_PropertyCallbackFunction pnpPropertyCallback, void* userContextCallback);
+
+
+
+//
+// PnP_ProcessModuleTwinConfigProperty is invoked by the application when a module twin arrives to its module twin processing callback.
+// PnP_ProcessModuleTwinConfigProperty will visit the children of the desired portion of the twin and invoke the modules's pnpPropertyCallback
+// function for the PnpBridgeConfig property that is used to configure the Pnp Bridge module's modelled components
+// 
+bool PnP_ProcessModuleTwinConfigProperty(DEVICE_TWIN_UPDATE_STATE updateState, const unsigned char* payload, size_t size, PnP_ModuleConfigPropertyCallbackFunction pnpPropertyCallback, const char* targetProperty);
 
 //
 // PnP_CopyTwinPayloadToString takes the payload data, which arrives as a potentially non-NULL terminated string from the IoTHub SDK, and creates

--- a/pnpbridge/src/pnpbridge/inc/configuration_parser.h
+++ b/pnpbridge/src/pnpbridge/inc/configuration_parser.h
@@ -89,6 +89,7 @@ typedef struct PNPBRIDGE_CONFIGURATION {
     // before a feature is used, a check should be made to see
     // if its available.
     BridgeFeatures Features;
+
 } PNPBRIDGE_CONFIGURATION;
 
 /**

--- a/pnpbridge/src/pnpbridge/inc/iothub_comms.h
+++ b/pnpbridge/src/pnpbridge/inc/iothub_comms.h
@@ -10,7 +10,7 @@ extern "C"
 
 #include <pnpadapter_manager.h>
 
-IOTHUB_CLIENT_RESULT IotComms_InitializeIotHandle(MX_IOT_HANDLE_TAG* IotHandle, bool TraceOn, PCONNECTION_PARAMETERS ConnectionParams);
+IOTHUB_CLIENT_RESULT IotComms_InitializeIotHandle(MX_IOT_HANDLE_TAG* IotHandle, PCONNECTION_PARAMETERS ConnectionParams);
 IOTHUB_CLIENT_RESULT IotComms_DeinitializeIotHandle(MX_IOT_HANDLE_TAG* IotHandle, PCONNECTION_PARAMETERS ConnectionParams);
 
 #ifdef __cplusplus

--- a/pnpbridge/src/pnpbridge/inc/pnpadapter_api.h
+++ b/pnpbridge/src/pnpbridge/inc/pnpadapter_api.h
@@ -15,6 +15,7 @@
 #include "pnp_device_client.h"
 #include "pnp_dps.h"
 #include "pnp_protocol.h"
+#include "pnp_bridge_client.h"
 
 #ifdef __cplusplus
 extern "C"
@@ -263,28 +264,15 @@ extern "C"
     );
 
     /**
-    * @brief    PnpComponentHandleGetIotHubDeviceClient gets the device client handle from the component handle
+    * @brief    PnpComponentHandleGetClientHandle gets the client handle from the component handle
 
     * @param    ComponentHandle               Handle to pnp component
     *
-    * @returns  IOTHUB_DEVICE_CLIENT_HANDLE   IoTHub Device Client handle
+    * @returns  PNP_BRIDGE_CLIENT_HANDLE      Client handle
     */
     MOCKABLE_FUNCTION(,
-        IOTHUB_DEVICE_CLIENT_HANDLE,
-        PnpComponentHandleGetIotHubDeviceClient,
-        PNPBRIDGE_COMPONENT_HANDLE, ComponentHandle
-    );
-
-    /**
-    * @brief    PnpComponentHandleGetIotHubModuleClient gets the module client handle from the component handle
-
-    * @param    ComponentHandle               Handle to pnp component
-    *
-    * @returns  IOTHUB_MODULE_CLIENT_HANDLE   IoTHub Module Client handle
-    */
-    MOCKABLE_FUNCTION(,
-        IOTHUB_MODULE_CLIENT_HANDLE,
-        PnpComponentHandleGetIotHubModuleClient,
+        PNP_BRIDGE_CLIENT_HANDLE,
+        PnpComponentHandleGetClientHandle,
         PNPBRIDGE_COMPONENT_HANDLE, ComponentHandle
     );
 

--- a/pnpbridge/src/pnpbridge/inc/pnpadapter_api.h
+++ b/pnpbridge/src/pnpbridge/inc/pnpadapter_api.h
@@ -10,11 +10,22 @@
 #include "umock_c/umock_c_prod.h"
 #include "parson.h"
 #include <iothub_device_client.h>
+#include <iothub_module_client.h>
+
+#include "pnp_device_client.h"
+#include "pnp_dps.h"
+#include "pnp_protocol.h"
 
 #ifdef __cplusplus
 extern "C"
 {
 #endif
+
+    // Pnp Bridge IoT type
+    typedef enum PNP_BRIDGE_IOT_TYPE {
+        PNP_BRIDGE_IOT_TYPE_DEVICE,
+        PNP_BRIDGE_IOT_TYPE_RUNTIME_MODULE
+    } PNP_BRIDGE_IOT_TYPE;
 
     // Pnp component handle
     typedef void* PNPBRIDGE_COMPONENT_HANDLE;
@@ -116,7 +127,7 @@ extern "C"
     * @brief    PNPBRIDGE_COMPONENT_START callback is invoked for each component in the configuration
     *           file after the IoT hub device client handle associated with the root interface of the
     *           pnp bridge has been registered with IoT hub. The pnp adapter should ensure that the component
-    *           starts reporting telenetry after this call is made and not before it.
+    *           starts reporting telemetry after this call is made and not before it.
     *
     * @param    PnpComponentHandle    Handle to Pnp component
     *
@@ -252,7 +263,7 @@ extern "C"
     );
 
     /**
-    * @brief    PnpComponentHandleGetIotHubDeviceClient gets device client handle from the component handle
+    * @brief    PnpComponentHandleGetIotHubDeviceClient gets the device client handle from the component handle
 
     * @param    ComponentHandle               Handle to pnp component
     *
@@ -261,6 +272,32 @@ extern "C"
     MOCKABLE_FUNCTION(,
         IOTHUB_DEVICE_CLIENT_HANDLE,
         PnpComponentHandleGetIotHubDeviceClient,
+        PNPBRIDGE_COMPONENT_HANDLE, ComponentHandle
+    );
+
+    /**
+    * @brief    PnpComponentHandleGetIotHubModuleClient gets the module client handle from the component handle
+
+    * @param    ComponentHandle               Handle to pnp component
+    *
+    * @returns  IOTHUB_MODULE_CLIENT_HANDLE   IoTHub Module Client handle
+    */
+    MOCKABLE_FUNCTION(,
+        IOTHUB_MODULE_CLIENT_HANDLE,
+        PnpComponentHandleGetIotHubModuleClient,
+        PNPBRIDGE_COMPONENT_HANDLE, ComponentHandle
+    );
+
+    /**
+    * @brief    PnpComponentHandleGetIoTType gets the type of client handle from the component handle (Module or Device)
+
+    * @param    ComponentHandle               Handle to pnp component
+    *
+    * @returns  PNP_BRIDGE_IOT_TYPE           Client Type (PNP_BRIDGE_IOT_TYPE_RUNTIME_MODULE or PNP_BRIDGE_IOT_TYPE_DEVICE)
+    */
+    MOCKABLE_FUNCTION(,
+        PNP_BRIDGE_IOT_TYPE,
+        PnpComponentHandleGetIoTType,
         PNPBRIDGE_COMPONENT_HANDLE, ComponentHandle
     );
 

--- a/pnpbridge/src/pnpbridge/inc/pnpadapter_manager.h
+++ b/pnpbridge/src/pnpbridge/inc/pnpadapter_manager.h
@@ -40,8 +40,8 @@ extern "C"
     // Pnp interface structure
     typedef struct _ {
         void* context;
-        const char* componentName;
-        const char* adapterIdentity;
+        char* componentName;
+        char* adapterIdentity;
         PNPBRIDGE_COMPONENT_PROPERTY_CALLBACK processPropertyUpdate;
         PNPBRIDGE_COMPONENT_METHOD_CALLBACK processCommand;
         IOTHUB_DEVICE_CLIENT_HANDLE deviceClient;
@@ -164,6 +164,13 @@ extern "C"
 
     static void PnpAdapterManager_ResumePnpBridgeAdapterAndComponentCreation(
         JSON_Value* pnpBridgeConfig);
+    
+    void PnpAdapterManager_SendPnpBridgeStateTelemetry(
+        const char * BridgeState);
+
+    static const char* PnpBridge_State = "ModuleState";
+    static const char* PnpBridge_WaitingForConfig = "Waiting for PnpBridge configuration property update";
+    static const char* PnpBridge_ConfigurationComplete = "PnpBridge configuration complete";
 
 #ifdef __cplusplus
 }

--- a/pnpbridge/src/pnpbridge/inc/pnpadapter_manager.h
+++ b/pnpbridge/src/pnpbridge/inc/pnpadapter_manager.h
@@ -105,7 +105,8 @@ extern "C"
 
     IOTHUB_CLIENT_RESULT PnpAdapterManager_CreateComponents(
         PPNP_ADAPTER_MANAGER adapterMgr,
-        JSON_Value* config);
+        JSON_Value* config,
+        PNP_BRIDGE_IOT_TYPE clientType);
 
     IOTHUB_CLIENT_RESULT PnpAdapterManager_GetAdapterHandle(
         PPNP_ADAPTER_MANAGER adapterMgr,
@@ -136,7 +137,8 @@ extern "C"
 
     IOTHUB_CLIENT_RESULT PnpAdapterManager_BuildAdaptersAndComponents(
         PPNP_ADAPTER_MANAGER * adapterMgr,
-        JSON_Value* config);
+        JSON_Value* config,
+        PNP_BRIDGE_IOT_TYPE clientType);
 
     // Device Twin callback is invoked by IoT SDK when a twin - either full twin or a PATCH update - arrives.
     void PnpAdapterManager_DeviceTwinCallback(

--- a/pnpbridge/src/pnpbridge/inc/pnpadapter_manager.h
+++ b/pnpbridge/src/pnpbridge/inc/pnpadapter_manager.h
@@ -125,6 +125,10 @@ extern "C"
         const char * ComponentName,
         size_t ComponentNameSize);
 
+    IOTHUB_CLIENT_RESULT PnpAdapterManager_BuildAdapterManagerAndStartComponents(
+        PPNP_ADAPTER_MANAGER adapterMgr,
+        JSON_Value* config);
+
     // Device Twin callback is invoked by IoT SDK when a twin - either full twin or a PATCH update - arrives.
     void PnpAdapterManager_DeviceTwinCallback(
         DEVICE_TWIN_UPDATE_STATE updateState,
@@ -148,6 +152,9 @@ extern "C"
         JSON_Value* propertyValue,
         int version,
         void* userContextCallback);
+
+    static void PnpAdapterManager_ResumePnpBridgeAdapterAndComponentCreation(
+        JSON_Value* pnpBridgeConfig);
 
 #ifdef __cplusplus
 }

--- a/pnpbridge/src/pnpbridge/inc/pnpadapter_manager.h
+++ b/pnpbridge/src/pnpbridge/inc/pnpadapter_manager.h
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 #pragma once
-#include <pnpbridge.h>
+#include "pnpadapter_api.h"
 
 #ifdef __cplusplus
 extern "C"
@@ -45,6 +45,8 @@ extern "C"
         PNPBRIDGE_COMPONENT_PROPERTY_CALLBACK processPropertyUpdate;
         PNPBRIDGE_COMPONENT_METHOD_CALLBACK processCommand;
         IOTHUB_DEVICE_CLIENT_HANDLE deviceClient;
+        IOTHUB_MODULE_CLIENT_HANDLE moduleClient;
+        PNP_BRIDGE_IOT_TYPE clientType;
     } PNPADAPTER_COMPONENT_TAG, * PPNPADAPTER_COMPONENT_TAG;
 
 
@@ -95,17 +97,24 @@ extern "C"
     IOTHUB_CLIENT_RESULT PnpAdapterManager_GetAdapterFromManifest(
         const char* adapterId,
         PPNP_ADAPTER* adapter);
+
     IOTHUB_CLIENT_RESULT PnpAdapterManager_CreateAdapter(
         const char* adapterId,
         PPNP_ADAPTER_CONTEXT_TAG* adapterContext,
         JSON_Value* config);
+
     IOTHUB_CLIENT_RESULT PnpAdapterManager_CreateComponents(
         PPNP_ADAPTER_MANAGER adapterMgr,
         JSON_Value* config);
+
     IOTHUB_CLIENT_RESULT PnpAdapterManager_GetAdapterHandle(
         PPNP_ADAPTER_MANAGER adapterMgr,
         const char* adapterIdentity,
         PPNP_ADAPTER_CONTEXT_TAG* adapterContext);
+
+    IOTHUB_CLIENT_RESULT PnpAdapterManager_InitializeClientHandle(
+        PPNPADAPTER_COMPONENT_TAG componentHandle);
+
     IOTHUB_CLIENT_RESULT PnpAdapterManager_StartComponents(
         PPNP_ADAPTER_MANAGER adapterMgr);
 
@@ -125,8 +134,8 @@ extern "C"
         const char * ComponentName,
         size_t ComponentNameSize);
 
-    IOTHUB_CLIENT_RESULT PnpAdapterManager_BuildAdapterManagerAndStartComponents(
-        PPNP_ADAPTER_MANAGER adapterMgr,
+    IOTHUB_CLIENT_RESULT PnpAdapterManager_BuildAdaptersAndComponents(
+        PPNP_ADAPTER_MANAGER * adapterMgr,
         JSON_Value* config);
 
     // Device Twin callback is invoked by IoT SDK when a twin - either full twin or a PATCH update - arrives.

--- a/pnpbridge/src/pnpbridge/inc/pnpadapter_manager.h
+++ b/pnpbridge/src/pnpbridge/inc/pnpadapter_manager.h
@@ -44,8 +44,7 @@ extern "C"
         char* adapterIdentity;
         PNPBRIDGE_COMPONENT_PROPERTY_CALLBACK processPropertyUpdate;
         PNPBRIDGE_COMPONENT_METHOD_CALLBACK processCommand;
-        IOTHUB_DEVICE_CLIENT_HANDLE deviceClient;
-        IOTHUB_MODULE_CLIENT_HANDLE moduleClient;
+        PNP_BRIDGE_CLIENT_HANDLE clientHandle;
         PNP_BRIDGE_IOT_TYPE clientType;
     } PNPADAPTER_COMPONENT_TAG, * PPNPADAPTER_COMPONENT_TAG;
 

--- a/pnpbridge/src/pnpbridge/inc/pnpbridge.h
+++ b/pnpbridge/src/pnpbridge/inc/pnpbridge.h
@@ -26,9 +26,6 @@
 #include "pnp_dps.h"
 #include "pnp_protocol.h"
 
-#include "pnpadapter_api.h"
-#include "pnpbridge_common.h"
-
 #ifdef __cplusplus
 extern "C"
 {

--- a/pnpbridge/src/pnpbridge/inc/pnpbridge.h
+++ b/pnpbridge/src/pnpbridge/inc/pnpbridge.h
@@ -25,6 +25,7 @@
 #include "pnp_device_client.h"
 #include "pnp_dps.h"
 #include "pnp_protocol.h"
+#include "pnp_bridge_client.h"
 
 #ifdef __cplusplus
 extern "C"

--- a/pnpbridge/src/pnpbridge/inc/pnpbridge_common.h
+++ b/pnpbridge/src/pnpbridge/inc/pnpbridge_common.h
@@ -137,9 +137,8 @@ typedef struct _MX_IOT_HANDLE_TAG {
         } IotModule;
     } u1;
 
-    // Change this to enum
     bool IsModule;
-    bool DeviceClientInitialized;
+    bool ClientHandleInitialized;
 } MX_IOT_HANDLE_TAG;
 
 typedef enum PNP_BRIDGE_STATE {
@@ -149,6 +148,11 @@ typedef enum PNP_BRIDGE_STATE {
     PNP_BRIDGE_DESTROYED
 } PNP_BRIDGE_STATE;
 
+typedef enum PNP_BRIDGE_IOT_EDGE {
+    PNP_BRIDGE_IOT_EDGE_DEVICE,
+    PNP_BRIDGE_IOT_EDGE_RUNTIME_MODULE
+} PNP_BRIDGE_IOT_EDGE;
+
 // Device aggregator context
 typedef struct _PNP_BRIDGE {
     MX_IOT_HANDLE_TAG IotHandle;
@@ -157,6 +161,8 @@ typedef struct _PNP_BRIDGE {
 
     PNPBRIDGE_CONFIGURATION Configuration;
 
+    PNP_BRIDGE_IOT_EDGE IoTEdgeType;
+
     COND_HANDLE ExitCondition;
 
     LOCK_HANDLE ExitLock;
@@ -164,6 +170,19 @@ typedef struct _PNP_BRIDGE {
 
 
 void PnpBridge_Release(PPNP_BRIDGE pnpBridge);
+
+// User Agent String for Pnp Bridge telemetry
+static const char g_pnpBridgeUserAgentString[] = "PnpBridgeUserAgentString";
+// Pnp Bridge desired property for component config
+static const char g_pnpBridgeConfigProperty[] = "PnpBridgeConfig";
+// Root Pnp Bridge Interface model ID when running as a module
+static const char g_pnpBridgeModuleRootModelId[] = "dtmi:com:example:RootPnpBridgeSampleDevice;1";
+// Environment variable used to specify this application's connection string when running as a module
+static const char g_connectionStringEnvironmentVariable[] = "IOTHUB_DEVICE_CONNECTION_STRING";
+// Environment variable used to specify workload URI for dockerized containers/modules
+static const char g_workloadURIEnvironmentVariable[] = "IOTEDGE_WORKLOADURI";
+// Hub client tracing for when Pnp Bridge runs in Edge Module
+static bool g_hubClientTraceEnabled = true;
 
 #ifdef __cplusplus
 }

--- a/pnpbridge/src/pnpbridge/inc/pnpbridge_common.h
+++ b/pnpbridge/src/pnpbridge/inc/pnpbridge_common.h
@@ -171,13 +171,13 @@ static const char g_pnpBridgeUserAgentString[] = "PnpBridgeUserAgentString";
 // Pnp Bridge desired property for component config
 static const char g_pnpBridgeConfigProperty[] = "PnpBridgeConfig";
 // Root Pnp Bridge Interface model ID when running as a module
-static const char g_pnpBridgeModuleRootModelId[] = "dtmi:com:example:RootPnpBridgeSampleDevice;1";
+static const char g_pnpBridgeModuleRootModelId[] = "PNP_BRIDGE_ROOT_MODEL_ID";
 // Environment variable used to specify this application's connection string when running as a module
 static const char g_connectionStringEnvironmentVariable[] = "IOTHUB_DEVICE_CONNECTION_STRING";
 // Environment variable used to specify workload URI for dockerized containers/modules
 static const char g_workloadURIEnvironmentVariable[] = "IOTEDGE_WORKLOADURI";
 // Hub client tracing for when Pnp Bridge runs in Edge Module
-static bool g_hubClientTraceEnabled = false;
+static const char g_hubClientTraceEnabled[] = "PNP_BRIDGE_HUB_TRACING_ENABLED";
 
 #ifdef __cplusplus
 }

--- a/pnpbridge/src/pnpbridge/inc/pnpbridge_common.h
+++ b/pnpbridge/src/pnpbridge/inc/pnpbridge_common.h
@@ -48,6 +48,10 @@ extern "C"
 #include "pnp_dps.h"
 #include "pnp_protocol.h"
 
+// Pnp Bridge headers
+#include "configuration_parser.h"
+#include "pnpadapter_manager.h"
+
 #include <assert.h>
 
 #define PNPBRIDGE_CLIENT_HANDLE void*
@@ -65,14 +69,10 @@ extern "C"
 MU_DEFINE_ENUM(PNPBRIDGE_RESULT, PNPBRIDGE_RESULT_VALUES);
 
 #define PNPBRIDGE_SUCCESS(Result) (Result == IOTHUB_CLIENT_OK)
-#include "configuration_parser.h"
-#include "pnpadapter_manager.h"
 
 MAP_RESULT Map_Add_Index(MAP_HANDLE handle, const char* key, int value);
 
 int Map_GetIndexValueFromKey(MAP_HANDLE handle, const char* key);
-
-#include <pnpbridge.h>
 
 #define PNP_CONFIG_CONNECTION_PARAMETERS "pnp_bridge_connection_parameters"
 #define PNP_CONFIG_TRACE_ON "pnp_bridge_debug_trace"
@@ -148,11 +148,6 @@ typedef enum PNP_BRIDGE_STATE {
     PNP_BRIDGE_DESTROYED
 } PNP_BRIDGE_STATE;
 
-typedef enum PNP_BRIDGE_IOT_EDGE {
-    PNP_BRIDGE_IOT_EDGE_DEVICE,
-    PNP_BRIDGE_IOT_EDGE_RUNTIME_MODULE
-} PNP_BRIDGE_IOT_EDGE;
-
 // Device aggregator context
 typedef struct _PNP_BRIDGE {
     MX_IOT_HANDLE_TAG IotHandle;
@@ -161,7 +156,7 @@ typedef struct _PNP_BRIDGE {
 
     PNPBRIDGE_CONFIGURATION Configuration;
 
-    PNP_BRIDGE_IOT_EDGE IoTEdgeType;
+    PNP_BRIDGE_IOT_TYPE IoTClientType;
 
     COND_HANDLE ExitCondition;
 
@@ -182,7 +177,7 @@ static const char g_connectionStringEnvironmentVariable[] = "IOTHUB_DEVICE_CONNE
 // Environment variable used to specify workload URI for dockerized containers/modules
 static const char g_workloadURIEnvironmentVariable[] = "IOTEDGE_WORKLOADURI";
 // Hub client tracing for when Pnp Bridge runs in Edge Module
-static bool g_hubClientTraceEnabled = true;
+static bool g_hubClientTraceEnabled = false;
 
 #ifdef __cplusplus
 }

--- a/pnpbridge/src/pnpbridge/inc/pnpbridge_common.h
+++ b/pnpbridge/src/pnpbridge/inc/pnpbridge_common.h
@@ -47,6 +47,7 @@ extern "C"
 #include "pnp_device_client.h"
 #include "pnp_dps.h"
 #include "pnp_protocol.h"
+#include "pnp_bridge_client.h"
 
 // Pnp Bridge headers
 #include "configuration_parser.h"
@@ -166,7 +167,7 @@ typedef struct _PNP_BRIDGE {
 
 void PnpBridge_Release(PPNP_BRIDGE pnpBridge);
 
-// User Agent String for Pnp Bridge telemetry
+// User Agent String for Pnp Bridge telemetry [THIS VALUE SHOULD NEVER BE CHANGED]
 static const char g_pnpBridgeUserAgentString[] = "PnpBridgeUserAgentString";
 // Pnp Bridge desired property for component config
 static const char g_pnpBridgeConfigProperty[] = "PnpBridgeConfig";

--- a/pnpbridge/src/pnpbridge/module/CMakeLists.txt
+++ b/pnpbridge/src/pnpbridge/module/CMakeLists.txt
@@ -1,0 +1,122 @@
+# Copyright (c) Microsoft. All rights reserved.
+# Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+cmake_minimum_required(VERSION 2.8.11)
+
+
+set(PROJECT_NAME pnpbridge_module)
+
+macro(compileAsC99)
+  if (CMAKE_VERSION VERSION_LESS "3.1")
+    if (CMAKE_C_COMPILER_ID STREQUAL "GNU")
+      set (CMAKE_C_FLAGS "--std=c99 ${CMAKE_C_FLAGS}")
+      set (CMAKE_CXX_FLAGS "--std=c++11 ${CMAKE_CXX_FLAGS}")
+    endif()
+  else()
+    set (CMAKE_C_STANDARD 99)
+    set (CMAKE_CXX_STANDARD 11)
+  endif()
+endmacro(compileAsC99)
+
+compileAsC99()
+
+# Core PnpBridge C Files
+set(pnp_bridge_c_core_files
+    ./main.c
+    ./../src/configuration_parser.c
+    ./../src/iothub_comms.c
+    ./../src/pnpadapter_manager.c
+    ./../src/pnpbridge.c
+    ./../src/utility.c
+    ./../src/pnpadapter_api.c
+)
+
+# Core PnpBridge headers
+set(pnp_bridge_h_core_files
+    ./../inc/configuration_parser.h
+    ./../inc/iothub_comms.h
+    ./../inc/pnpadapter_api.h
+    ./../inc/pnpadapter_manager.h
+    ./../inc/pnpbridge.h
+    ./../inc/pnpbridge_common.h
+)
+
+# Pnp Common Helper C Files
+set(pnp_helper_c_core_files
+    ./../common/pnp_device_client.c
+    ./../common/pnp_dps.c
+    ./../common/pnp_protocol.c
+)
+
+# Pnp Common Helper headers
+set(pnp_helper_h_core_files
+    ./../common/pnp_device_client.h
+    ./../common/pnp_dps.h
+    ./../common/pnp_protocol.h
+)
+
+# set(install_staticlibs
+    # ${PROJECT_NAME}
+# )
+
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -DUSE_EDGE_MODULES")
+set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -DUSE_EDGE_MODULES")
+
+add_definitions(-DPNP_LOGGING_ENABLED)
+
+# set(pnp_bridge_h_install_files
+    # ${pnp_bridge_h_files}
+# )
+
+set(AZUREIOT_INC_FOLDER "/usr/include/azureiot" "/usr/include/azureiot/inc")
+
+include_directories(${AZUREIOT_INC_FOLDER})
+include_directories(inc)
+include_directories(common)
+include_directories(../../deps/azure-iot-sdk-c-pnp/deps/parson)
+include_directories(../../deps/azure-iot-sdk-c-pnp/c-utility/inc)
+include_directories(../../deps/azure-iot-sdk-c-pnp/c-utility/deps/azure-macro-utils-c/inc)
+include_directories(../../deps/azure-iot-sdk-c-pnp/c-utility/deps/umock-c/inc)
+include_directories(../../deps/azure-iot-sdk-c-pnp/iothub_client/inc)
+include_directories(../../deps/azure-iot-sdk-c-pnp/provisioning_client/inc)
+
+set(pnp_bridge_common_libs
+    aziotsharedutil
+    pnpbridge
+    iothub_client
+    iothub_client_http_transport
+    iothub_client_amqp_transport
+    iothub_client_amqp_ws_transport
+    iothub_client_mqtt_transport
+    iothub_client_mqtt_ws_transport
+    parson
+    umqtt
+    msr_riot
+    hsm_security_client
+    prov_auth_client
+    prov_device_client
+    prov_mqtt_transport
+    utpm
+    uhttp
+    pthread
+    curl
+    ssl
+    crypto
+    m
+    uuid
+    pnpbridge_adapters
+    pnpbridge_modbus
+    pnpbridge_mqtt
+    pnpbridge_serial
+    pnpbridge_environmentalsensor
+)
+
+
+add_executable(${PROJECT_NAME}
+    ${pnp_bridge_c_core_files}
+    ${pnp_bridge_h_core_files}
+    ${pnp_helper_c_core_files}
+    ${pnp_helper_h_core_files}
+)
+
+target_link_libraries(${PROJECT_NAME} ${pnp_bridge_common_libs})

--- a/pnpbridge/src/pnpbridge/module/CMakeLists.txt
+++ b/pnpbridge/src/pnpbridge/module/CMakeLists.txt
@@ -53,6 +53,7 @@ set(pnp_helper_h_core_files
     ./../common/pnp_device_client.h
     ./../common/pnp_dps.h
     ./../common/pnp_protocol.h
+    ./../common/pnp_bridge_client.h
 )
 
 # set(install_staticlibs
@@ -61,6 +62,9 @@ set(pnp_helper_h_core_files
 
 set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -DUSE_EDGE_MODULES")
 set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -DUSE_EDGE_MODULES")
+
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -DUSE_MODULE_CLIENT")
+set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -DUSE_MODULE_CLIENT")
 
 add_definitions(-DPNP_LOGGING_ENABLED)
 

--- a/pnpbridge/src/pnpbridge/module/main.c
+++ b/pnpbridge/src/pnpbridge/module/main.c
@@ -1,0 +1,12 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+#include "pnpbridge.h"
+#include "azure_c_shared_utility/xlogging.h"
+
+int main()
+{
+    LogInfo("\n --Running Azure IoT PnP Bridge as an IoT Edge Runtime Module\n");
+    PnpBridge_Main(NULL);
+    return 0;
+}

--- a/pnpbridge/src/pnpbridge/samples/CMakeLists.txt
+++ b/pnpbridge/src/pnpbridge/samples/CMakeLists.txt
@@ -1,19 +1,5 @@
 # Copyright (c) Microsoft. All rights reserved.
 # Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-#this is CMakeLists.txt for PnP samples.
-
-#usePermissiveRulesForSdkSamplesAndTests()
-
-# function(add_sample_directory whatIsBuilding)
-    # add_subdirectory(${whatIsBuilding})
-
-    # set_target_properties(${whatIsBuilding}
-               # PROPERTIES
-               # FOLDER "PnPBridge_Adapters_Samples")
-# endfunction()
-
-# add_sample_directory(environment_sensor)
-
 add_subdirectory(console)
 add_subdirectory(service)

--- a/pnpbridge/src/pnpbridge/samples/console/CMakeLists.txt
+++ b/pnpbridge/src/pnpbridge/samples/console/CMakeLists.txt
@@ -75,6 +75,7 @@ set(pnp_bridge_common_libs
     pnpbridge_modbus
     pnpbridge_mqtt
     pnpbridge_serial
+    pnpbridge_environmentalsensor
 )
 
 if(WIN32)

--- a/pnpbridge/src/pnpbridge/samples/service/windows/CMakeLists.txt
+++ b/pnpbridge/src/pnpbridge/samples/service/windows/CMakeLists.txt
@@ -80,6 +80,7 @@ set(pnp_bridge_common_libs
     pnpbridge
     pnpbridge_modbus
     pnpbridge_serial
+    pnpbridge_environmentalsensor
 )
 
 

--- a/pnpbridge/src/pnpbridge/src/pnpadapter_api.c
+++ b/pnpbridge/src/pnpbridge/src/pnpadapter_api.c
@@ -49,3 +49,15 @@ IOTHUB_DEVICE_CLIENT_HANDLE PnpComponentHandleGetIotHubDeviceClient(PNPBRIDGE_CO
     PPNPADAPTER_COMPONENT_TAG componentContextTag = (PPNPADAPTER_COMPONENT_TAG)ComponentHandle;
     return componentContextTag->deviceClient;
 }
+
+IOTHUB_MODULE_CLIENT_HANDLE PnpComponentHandleGetIotHubModuleClient(PNPBRIDGE_COMPONENT_HANDLE ComponentHandle)
+{
+    PPNPADAPTER_COMPONENT_TAG componentContextTag = (PPNPADAPTER_COMPONENT_TAG)ComponentHandle;
+    return componentContextTag->moduleClient;
+}
+
+PNP_BRIDGE_IOT_TYPE PnpComponentHandleGetIoTType(PNPBRIDGE_COMPONENT_HANDLE ComponentHandle)
+{
+    PPNPADAPTER_COMPONENT_TAG componentContextTag = (PPNPADAPTER_COMPONENT_TAG)ComponentHandle;
+    return componentContextTag->clientType;
+}

--- a/pnpbridge/src/pnpbridge/src/pnpadapter_api.c
+++ b/pnpbridge/src/pnpbridge/src/pnpadapter_api.c
@@ -44,16 +44,10 @@ void PnpComponentHandleSetCommandCallback (PNPBRIDGE_COMPONENT_HANDLE ComponentH
     componentContextTag->processCommand = CommandCallback;
 }
 
-IOTHUB_DEVICE_CLIENT_HANDLE PnpComponentHandleGetIotHubDeviceClient(PNPBRIDGE_COMPONENT_HANDLE ComponentHandle)
+PNP_BRIDGE_CLIENT_HANDLE PnpComponentHandleGetClientHandle(PNPBRIDGE_COMPONENT_HANDLE ComponentHandle)
 {
     PPNPADAPTER_COMPONENT_TAG componentContextTag = (PPNPADAPTER_COMPONENT_TAG)ComponentHandle;
-    return componentContextTag->deviceClient;
-}
-
-IOTHUB_MODULE_CLIENT_HANDLE PnpComponentHandleGetIotHubModuleClient(PNPBRIDGE_COMPONENT_HANDLE ComponentHandle)
-{
-    PPNPADAPTER_COMPONENT_TAG componentContextTag = (PPNPADAPTER_COMPONENT_TAG)ComponentHandle;
-    return componentContextTag->moduleClient;
+    return componentContextTag->clientHandle;
 }
 
 PNP_BRIDGE_IOT_TYPE PnpComponentHandleGetIoTType(PNPBRIDGE_COMPONENT_HANDLE ComponentHandle)

--- a/pnpbridge/src/pnpbridge/src/pnpadapter_manager.c
+++ b/pnpbridge/src/pnpbridge/src/pnpadapter_manager.c
@@ -396,11 +396,11 @@ IOTHUB_CLIENT_RESULT PnpAdapterManager_InitializeClientHandle(
     }
     else if (componentHandle->clientType == PNP_BRIDGE_IOT_TYPE_RUNTIME_MODULE)
     {
-        componentHandle->moduleClient = g_PnpBridge->IotHandle.u1.IotModule.moduleHandle;
+        componentHandle->clientHandle = g_PnpBridge->IotHandle.u1.IotModule.moduleHandle;
     }
     else
     {
-        componentHandle->deviceClient = g_PnpBridge->IotHandle.u1.IotDevice.deviceHandle;
+        componentHandle->clientHandle = g_PnpBridge->IotHandle.u1.IotModule.moduleHandle;
     }
 
 exit:

--- a/pnpbridge/src/pnpbridge/src/pnpbridge.c
+++ b/pnpbridge/src/pnpbridge/src/pnpbridge.c
@@ -14,6 +14,159 @@ PPNP_BRIDGE g_PnpBridge = NULL;
 PNP_BRIDGE_STATE g_PnpBridgeState = PNP_BRIDGE_UNINITIALIZED;
 bool g_PnpBridgeShutdown = false;
 
+
+IOTHUB_CLIENT_RESULT
+PnpBridge_InitializePnpModuleConfig(PNP_DEVICE_CONFIGURATION * PnpModuleConfig)
+{
+    PnpModuleConfig->deviceMethodCallback = (IOTHUB_CLIENT_DEVICE_METHOD_CALLBACK_ASYNC) PnpAdapterManager_DeviceMethodCallback;
+    PnpModuleConfig->deviceTwinCallback = (IOTHUB_CLIENT_DEVICE_TWIN_CALLBACK) PnpAdapterManager_DeviceTwinCallback;
+    PnpModuleConfig->enableTracing = g_hubClientTraceEnabled;
+    PnpModuleConfig->modelId = g_pnpBridgeModuleRootModelId;
+    PnpModuleConfig->UserAgentString = g_pnpBridgeUserAgentString;
+    PnpModuleConfig->securityType = PNP_CONNECTION_SECURITY_TYPE_CONNECTION_STRING;
+    PnpModuleConfig->u.connectionString = getenv(g_connectionStringEnvironmentVariable);
+    return IOTHUB_CLIENT_OK;
+}
+
+IOTHUB_CLIENT_RESULT
+PnpBridge_InitializePnpDeviceConfig(PNPBRIDGE_CONFIGURATION * Configuration)
+{
+    IOTHUB_CLIENT_RESULT result = IOTHUB_CLIENT_OK;
+
+    Configuration->ConnParams->PnpDeviceConfiguration.deviceMethodCallback = (IOTHUB_CLIENT_DEVICE_METHOD_CALLBACK_ASYNC) PnpAdapterManager_DeviceMethodCallback;
+    Configuration->ConnParams->PnpDeviceConfiguration.deviceTwinCallback = (IOTHUB_CLIENT_DEVICE_TWIN_CALLBACK) PnpAdapterManager_DeviceTwinCallback;
+    Configuration->ConnParams->PnpDeviceConfiguration.enableTracing = Configuration->TraceOn;
+    Configuration->ConnParams->PnpDeviceConfiguration.modelId = Configuration->ConnParams->RootInterfaceModelId;
+    Configuration->ConnParams->PnpDeviceConfiguration.UserAgentString = g_pnpBridgeUserAgentString;
+
+    if (Configuration->ConnParams != NULL)
+    {
+        if (Configuration->ConnParams->ConnectionType == CONNECTION_TYPE_CONNECTION_STRING)
+        {
+            Configuration->ConnParams->PnpDeviceConfiguration.securityType = PNP_CONNECTION_SECURITY_TYPE_CONNECTION_STRING;
+            if (AUTH_TYPE_SYMMETRIC_KEY == Configuration->ConnParams->AuthParameters.AuthType)
+            {
+                char* format = NULL;
+
+                if (NULL != strstr(Configuration->ConnParams->u1.ConnectionString, "SharedAccessKey="))
+                {
+                    LogInfo("WARNING: SharedAccessKey is included in connection string. Ignoring "
+                        PNP_CONFIG_CONNECTION_AUTH_TYPE_DEVICE_SYMM_KEY " in config file.");
+                    Configuration->ConnParams->PnpDeviceConfiguration.u.connectionString = (char*)Configuration->ConnParams->u1.ConnectionString;
+                }
+                else
+                {
+                    format = "%s;SharedAccessKey=%s";
+                    Configuration->ConnParams->PnpDeviceConfiguration.u.connectionString = (char*)malloc(strlen(Configuration->ConnParams->AuthParameters.u1.DeviceKey) +
+                        strlen(Configuration->ConnParams->u1.ConnectionString) + strlen(format) + 1);
+                    sprintf(Configuration->ConnParams->PnpDeviceConfiguration.u.connectionString, format, Configuration->ConnParams->u1.ConnectionString,
+                        Configuration->ConnParams->AuthParameters.u1.DeviceKey);
+                }
+            }
+            else
+            {
+                LogError("Auth type (%d) is not supported for symmetric key", Configuration->ConnParams->AuthParameters.AuthType);
+                goto exit;
+            }
+        }
+        else if (Configuration->ConnParams->ConnectionType == CONNECTION_TYPE_DPS)
+        {
+            Configuration->ConnParams->PnpDeviceConfiguration.securityType = PNP_CONNECTION_SECURITY_TYPE_DPS;
+            if (AUTH_TYPE_SYMMETRIC_KEY == Configuration->ConnParams->AuthParameters.AuthType)
+            {
+                Configuration->ConnParams->PnpDeviceConfiguration.u.dpsConnectionAuth.endpoint =  Configuration->ConnParams->u1.Dps.GlobalProvUri;
+                Configuration->ConnParams->PnpDeviceConfiguration.u.dpsConnectionAuth.idScope = Configuration->ConnParams->u1.Dps.IdScope;
+                Configuration->ConnParams->PnpDeviceConfiguration.u.dpsConnectionAuth.deviceId = Configuration->ConnParams->u1.Dps.DeviceId;
+                Configuration->ConnParams->PnpDeviceConfiguration.u.dpsConnectionAuth.deviceKey = Configuration->ConnParams->AuthParameters.u1.DeviceKey;
+            }
+            else
+            {
+                LogError("Auth type (%d) is not supported for DPS", Configuration->ConnParams->AuthParameters.AuthType);
+                goto exit;
+            }
+        }
+        else
+        {
+            LogError("Connection type (%d) is not supported", Configuration->ConnParams->ConnectionType);
+            goto exit;
+        }
+    }
+exit:
+    return result;
+}
+
+IOTHUB_CLIENT_RESULT
+PnpBridge_InitializeEdgeModuleConfig(PNPBRIDGE_CONFIGURATION * Configuration)
+{
+    IOTHUB_CLIENT_RESULT result = IOTHUB_CLIENT_OK;
+    Configuration->Features.ModuleClient = 1;
+    Configuration->TraceOn = g_hubClientTraceEnabled;
+    Configuration->ConnParams = (PCONNECTION_PARAMETERS)calloc(1, sizeof(CONNECTION_PARAMETERS));
+    if (NULL == Configuration->ConnParams)
+    {
+        LogError("Failed to allocate CONNECTION_PARAMETERS for edge module.");
+        result = IOTHUB_CLIENT_ERROR;
+        goto exit;
+    }
+    Configuration->ConnParams->ConnectionType = CONNECTION_TYPE_EDGE_MODULE;
+    Configuration->ConnParams->RootInterfaceModelId = g_pnpBridgeModuleRootModelId;
+    Configuration->ConnParams->u1.ConnectionString = getenv(g_connectionStringEnvironmentVariable);
+    result = PnpBridge_InitializePnpModuleConfig(&Configuration->ConnParams->PnpDeviceConfiguration);
+    if (IOTHUB_CLIENT_OK != result)
+    {
+        LogError("Failed to retrieve the bridge configuration from specified file location.");
+        goto exit;
+    }
+
+exit:
+    return result;
+}
+
+IOTHUB_CLIENT_RESULT
+PnpBridge_InitializeDeviceConfig(PNPBRIDGE_CONFIGURATION * Configuration, const char * ConfigFilePath)
+{
+    IOTHUB_CLIENT_RESULT result = IOTHUB_CLIENT_OK;
+    JSON_Value* config = NULL;
+
+    // Get the Json value from configuration file
+    result = PnpBridgeConfig_GetJsonValueFromConfigFile(ConfigFilePath, &config);
+    if (IOTHUB_CLIENT_OK != result)
+    {
+        LogError("Failed to retrieve the bridge configuration from specified file location.");
+        goto exit;
+    }
+
+    // Check if config file has required parameters, and if so retrieve them
+    // This call also internally allocated memory for and initializes Json config
+    // and Connection Parameters, if all the validation succeeds
+    result = PnpBridgeConfig_RetrieveConfiguration(config, Configuration);
+    if (IOTHUB_CLIENT_OK != result)
+    {
+        LogError("Config file is invalid");
+        goto exit;
+    }
+
+    result = PnpBridge_InitializePnpDeviceConfig(Configuration);
+    if (IOTHUB_CLIENT_OK != result)
+    {
+        LogError("Pnp device configuration failed to initialize.");
+        goto exit;
+    }
+
+exit:
+    return result;
+}
+
+bool
+PnpBridge_IsRunningInEdgeRuntime()
+{
+    bool dockerizedModule = false;
+    const char * iotEdgeWorkLoadUri = getenv(g_workloadURIEnvironmentVariable);
+    dockerizedModule = (iotEdgeWorkLoadUri != NULL);
+    LogInfo("%s", ((dockerizedModule) ? "Pnp Bridge is running in a dockerized edge module." : "Pnp Bridge is running as am IoT egde device."));
+    return dockerizedModule;
+}
+
 IOTHUB_CLIENT_RESULT 
 PnpBridge_Initialize(
     PPNP_BRIDGE* PnpBridge,
@@ -22,7 +175,6 @@ PnpBridge_Initialize(
 {
     IOTHUB_CLIENT_RESULT result = IOTHUB_CLIENT_OK;
     PPNP_BRIDGE pbridge = NULL;
-    JSON_Value* config = NULL;
     bool lockAcquired = false;
 
     {
@@ -52,23 +204,28 @@ PnpBridge_Initialize(
         Lock(pbridge->ExitLock);
         lockAcquired = true;
 
-        // Get the JSON VALUE of configuration file
-        result = PnpBridgeConfig_GetJsonValueFromConfigFile(ConfigFilePath, &config);
-        if (IOTHUB_CLIENT_OK != result) {
-            LogError("Failed to retrieve the bridge configuration from specified file location.");
-            goto exit;
+        if (PnpBridge_IsRunningInEdgeRuntime())
+        {
+            pbridge->IoTEdgeType = PNP_BRIDGE_IOT_EDGE_RUNTIME_MODULE;
+            result = PnpBridge_InitializeEdgeModuleConfig(&pbridge->Configuration);
+            if (IOTHUB_CLIENT_OK != result) {
+                LogError("Failed to initilize IoT Edge Runtime module configuration for module client handle");
+                goto exit;
+            }
+            LogInfo("IoT Edge Module configuration initialized successfully");
         }
-
-        // Check if config file has REQUIRED parameters
-        result = PnpBridgeConfig_RetrieveConfiguration(config, &pbridge->Configuration);
-        if (IOTHUB_CLIENT_OK != result) {
-            LogError("Config file is invalid");
-            goto exit;
+        else
+        {
+            pbridge->IoTEdgeType = PNP_BRIDGE_IOT_EDGE_DEVICE;
+            result = PnpBridge_InitializeDeviceConfig(&pbridge->Configuration, ConfigFilePath);
+            if (IOTHUB_CLIENT_OK != result) {
+                LogError("Failed to initialize Pnp Bridge device configuration");
+                goto exit;
+            }
+            LogInfo("IoT Edge Device configuration initialized successfully");
         }
 
         *PnpBridge = pbridge;
-
-        g_PnpBridgeState = PNP_BRIDGE_INITIALIZED;
     }
 exit:
     {
@@ -89,8 +246,7 @@ PnpBridge_RegisterIoTHubHandle()
 {
     IOTHUB_CLIENT_RESULT result = IOTHUB_CLIENT_OK;
 
-    result = IotComms_InitializeIotHandle(&g_PnpBridge->IotHandle,
-        g_PnpBridge->Configuration.TraceOn, g_PnpBridge->Configuration.ConnParams);
+    result = IotComms_InitializeIotHandle(&g_PnpBridge->IotHandle, g_PnpBridge->Configuration.ConnParams);
     if (IOTHUB_CLIENT_OK != result) {
         LogError("IotComms_InitializeIotHandle failed.");
         result = IOTHUB_CLIENT_ERROR;
@@ -169,27 +325,6 @@ PnpBridge_Main(const char * ConfigurationFilePath)
 
             g_PnpBridge = pnpBridge;
 
-            LogInfo("Building Pnp Bridge Adapter Manager & Adapters");
-
-            // Create all the adapters that are required by configured devices
-            result = PnpAdapterManager_CreateManager(&pnpBridge->PnpMgr, pnpBridge->Configuration.JsonConfig);
-            if (IOTHUB_CLIENT_OK != result) {
-                LogError("PnpAdapterManager_CreateManager failed: %d", result);
-                goto exit;
-            }
-
-            result = PnpAdapterManager_CreateComponents(pnpBridge->PnpMgr, pnpBridge->Configuration.JsonConfig);
-            if (IOTHUB_CLIENT_OK != result) {
-                LogError("PnpAdapterManager_CreateComponents failed: %d", result);
-                goto exit;
-            }
-
-            result = PnpAdapterManager_BuildComponentsInModel(pnpBridge->PnpMgr);
-            if (IOTHUB_CLIENT_OK != result) {
-                LogError("PnpAdapterManager_BuildComponentsInModel failed: %d", result);
-                goto exit;
-            }
-
             result = PnpBridge_RegisterIoTHubHandle();
             if (IOTHUB_CLIENT_OK != result) {
                 LogError("PnpBridge_RegisterIoTHubHandle failed: %d", result);
@@ -198,11 +333,15 @@ PnpBridge_Main(const char * ConfigurationFilePath)
 
             LogInfo("Connected to Azure IoT Hub");
 
-
-            result = PnpAdapterManager_StartComponents(pnpBridge->PnpMgr);
-            if (IOTHUB_CLIENT_OK != result) {
-                LogError("PnpAdapterManager_StartComponents failed: %d", result);
-                goto exit;
+            if (g_PnpBridge->IoTEdgeType == PNP_BRIDGE_IOT_EDGE_DEVICE)
+            {
+                result = PnpAdapterManager_BuildAdapterManagerAndStartComponents(pnpBridge->PnpMgr, pnpBridge->Configuration.JsonConfig);
+                if (IOTHUB_CLIENT_OK != result)
+                {
+                    LogError("PnpAdapterManager_BuildAdapterManagerAndStartComponents failed: %d", result);
+                    goto exit;
+                }
+                g_PnpBridgeState = PNP_BRIDGE_INITIALIZED;
             }
 
             // Prevent main thread from returning by waiting for the
@@ -260,7 +399,7 @@ PnpBridge_UploadToBlobAsync(
     IOTHUB_CLIENT_RESULT    iotResult = IOTHUB_CLIENT_OK;
     IOTHUB_CLIENT_HANDLE handle = NULL;
 
-    if (!g_PnpBridge->IotHandle.DeviceClientInitialized)
+    if (!g_PnpBridge->IotHandle.ClientHandleInitialized)
     {
         return IOTHUB_CLIENT_ERROR;
     }

--- a/pnpbridge/src/pnpbridge/src/pnpbridge.c
+++ b/pnpbridge/src/pnpbridge/src/pnpbridge.c
@@ -22,6 +22,7 @@ PnpBridge_InitializePnpModuleConfig(PNP_DEVICE_CONFIGURATION * PnpModuleConfig)
     PnpModuleConfig->deviceTwinCallback = (IOTHUB_CLIENT_DEVICE_TWIN_CALLBACK) PnpAdapterManager_DeviceTwinCallback;
     PnpModuleConfig->enableTracing = (strcmp(getenv(g_hubClientTraceEnabled), "true") == 0);
     PnpModuleConfig->modelId = getenv(g_pnpBridgeModuleRootModelId);
+    // Note: User Agent String should not be changed
     PnpModuleConfig->UserAgentString = g_pnpBridgeUserAgentString;
     PnpModuleConfig->securityType = PNP_CONNECTION_SECURITY_TYPE_CONNECTION_STRING;
     PnpModuleConfig->u.connectionString = getenv(g_connectionStringEnvironmentVariable);
@@ -37,6 +38,7 @@ PnpBridge_InitializePnpDeviceConfig(PNPBRIDGE_CONFIGURATION * Configuration)
     Configuration->ConnParams->PnpDeviceConfiguration.deviceTwinCallback = (IOTHUB_CLIENT_DEVICE_TWIN_CALLBACK) PnpAdapterManager_DeviceTwinCallback;
     Configuration->ConnParams->PnpDeviceConfiguration.enableTracing = Configuration->TraceOn;
     Configuration->ConnParams->PnpDeviceConfiguration.modelId = Configuration->ConnParams->RootInterfaceModelId;
+    // Note: User Agent String should not be changed
     Configuration->ConnParams->PnpDeviceConfiguration.UserAgentString = g_pnpBridgeUserAgentString;
 
     if (Configuration->ConnParams != NULL)


### PR DESCRIPTION
Adding Pnp Bridge Edge Module support:
 - Pnp Bridge core supports running as an edge module on linux gateway running Edge Runtime
 - Pnp Bridge supports protocol translation for devices using adapters with linux support (Environmental Sensor, Modbus, Mqtt and Serial PnP)
 - Adapter and component configuration for Bridge running as module is supported through module twin's desired property "PnpBridgeConfig"
 - Bridge core reports Bridge status telemetry (Waiting for Configuration or Configuration Complete)
 - Environmental Sensor adapter is now built with Bridge executable
 - Client handle registration when running as module is frontloaded to receive property update for adapter configuration.
 
Validatation:
- [x] Validate Pnp Bridge functionality (telemetry, properties, commands) running as Edge device using linux adapters
- [x] Complete validation of Pnp Bridge functionality on Linux containers running in an Edge module