### PR TITLE
Fix issues in MQTT Adapter

### DIFF
--- a/pnpbridge/src/adapters/src/mqtt_pnp/mqtt_pnp.cpp
+++ b/pnpbridge/src/adapters/src/mqtt_pnp/mqtt_pnp.cpp
@@ -127,7 +127,7 @@ MqttPnp_CreatePnpComponent(
     const char* mqtt_server = json_object_get_string(AdapterComponentConfig, PNP_CONFIG_ADAPTER_MQTT_SERVER);
     int mqtt_port = (int) json_object_get_number(AdapterComponentConfig, PNP_CONFIG_ADAPTER_MQTT_PORT);
     const char* protocol = json_object_get_string(AdapterComponentConfig, PNP_CONFIG_ADAPTER_MQTT_PROTOCOL);
-    const char* mqttConfigId = json_object_get_string(AdapterComponentConfig, PNP_CONFIG_ADAPTER_MQTT_SUPPORTED_CONFIG);
+    const char* mqttConfigId = json_object_get_string(AdapterComponentConfig, PNP_CONFIG_ADAPTER_MQTT_IDENTITY);
 
     MqttPnpAdapter* adapterContext = reinterpret_cast<MqttPnpAdapter*>(PnpAdapterHandleGetContext(AdapterHandle));
     if (adapterContext == NULL)

--- a/pnpbridge/src/adapters/src/mqtt_pnp/mqtt_pnp.hpp
+++ b/pnpbridge/src/adapters/src/mqtt_pnp/mqtt_pnp.hpp
@@ -29,4 +29,4 @@ public:
 #define PNP_CONFIG_ADAPTER_MQTT_PROTOCOL "mqtt_protocol"
 #define PNP_CONFIG_ADAPTER_MQTT_SERVER "mqtt_server"
 #define PNP_CONFIG_ADAPTER_MQTT_PORT "mqtt_port"
-#define PNP_CONFIG_ADAPTER_MQTT_SUPPORTED_CONFIG "mqtt_identity"
+#define PNP_CONFIG_ADAPTER_MQTT_SUPPORTED_CONFIG "json_rpc_1"

--- a/pnpbridge/src/adapters/src/mqtt_pnp/mqtt_pnp.hpp
+++ b/pnpbridge/src/adapters/src/mqtt_pnp/mqtt_pnp.hpp
@@ -29,4 +29,4 @@ public:
 #define PNP_CONFIG_ADAPTER_MQTT_PROTOCOL "mqtt_protocol"
 #define PNP_CONFIG_ADAPTER_MQTT_SERVER "mqtt_server"
 #define PNP_CONFIG_ADAPTER_MQTT_PORT "mqtt_port"
-#define PNP_CONFIG_ADAPTER_MQTT_SUPPORTED_CONFIG "json_rpc_1"
+#define PNP_CONFIG_ADAPTER_MQTT_SUPPORTED_CONFIG "mqtt_identity"

--- a/pnpbridge/src/pnpbridge/samples/console/config.json
+++ b/pnpbridge/src/pnpbridge/samples/console/config.json
@@ -71,7 +71,7 @@
         "pnp_bridge_component_name": "mqttdevice1",
         "pnp_bridge_adapter_id": "mqtt-pnp-interface",
         "pnp_bridge_adapter_config": {
-            "mqtt_port": "1",
+            "mqtt_port": 1,
             "mqtt_server": "1.1.1.1",
             "mqtt_protocol": "json_rpc",
             "mqtt_identity": "json_rpc_1"


### PR DESCRIPTION
This PR fixes the issues in MQTT Adapter that were causing failure to build
- incorrect json key in header file
- changed mqtt port in config file from string to int