### PR TITLE
Fixing bridge module build warnings on ARM linux

### DIFF
--- a/pnpbridge/src/adapters/samples/environmental_sensor/CMakeLists.txt
+++ b/pnpbridge/src/adapters/samples/environmental_sensor/CMakeLists.txt
@@ -28,9 +28,7 @@ add_definitions("-D_UNICODE")
 
 set(pnp_bridge_INC_FOLDER ${CMAKE_CURRENT_LIST_DIR}/../pnpbridge/inc CACHE INTERNAL "this is what needs to be included if using pnp_bridge lib" FORCE)
 set(pnp_bridge_common_pnp_inc ${CMAKE_CURRENT_LIST_DIR}/../pnpbridge/common CACHE INTERNAL "this is what needs to be included if using pnp_bridge lib" FORCE)
-set(AZUREIOT_INC_FOLDER "/usr/include/azureiot" "/usr/include/azureiot/inc")
 
-include_directories(${AZUREIOT_INC_FOLDER})
 include_directories(../../deps/azure-iot-sdk-c-pnp/deps/parson)
 include_directories(../../deps/azure-iot-sdk-c-pnp/c-utility/inc)
 include_directories(../../deps/azure-iot-sdk-c-pnp/c-utility/deps/azure-macro-utils-c/inc)
@@ -53,29 +51,9 @@ add_library(${PROJECT_NAME} STATIC
     ${pnpbridge_adaptersample_h_files}
 )
 
-set(pnp_bridge_common_libs
-    aziotsharedutil
-    pnpbridge
-    iothub_client 
-    iothub_client_http_transport
-    iothub_client_amqp_transport
-    iothub_client_amqp_ws_transport
-    iothub_client_mqtt_transport
-    iothub_client_mqtt_ws_transport
-    parson
-    umqtt
-    msr_riot
-    hsm_security_client
-    prov_auth_client
-    prov_device_client
-    prov_mqtt_transport
-    utpm
-)
-
 # add_executable(${PROJECT_NAME}
     # ${pnpbridge_adaptersample_c_files}
     # ${pnpbridge_adaptersample_h_files}
 # )
-target_link_libraries(${PROJECT_NAME} ${pnp_bridge_common_libs})
 
 configure_file(./config.json config.json COPYONLY)

--- a/pnpbridge/src/adapters/src/bluetooth_sensor/BluetoothSensorDeviceAdapterBase.cpp
+++ b/pnpbridge/src/adapters/src/bluetooth_sensor/BluetoothSensorDeviceAdapterBase.cpp
@@ -98,13 +98,9 @@ void BluetoothSensorDeviceAdapterBase::OnTelemetryCallback(
 {
     if (telemetryStatus != IOTHUB_CLIENT_OK)
     {
-        LogError("Bluetooth Sensor Component: Telemetry callback reported error: %d",
-            telemetryStatus);
-    }
-    else
-    {
-        LogInfo("Bluetooth Sensor Component: Telemetry %s was reported correctly",
-            (char*)userContextCallback);
+        LogError("Bluetooth Sensor Component: Telemetry callback reported error: %d, usercontext: 0x%p",
+            telemetryStatus, userContextCallback);
+        return;
     }
 }
 

--- a/pnpbridge/src/adapters/src/modbus_pnp/CMakeLists.txt
+++ b/pnpbridge/src/adapters/src/modbus_pnp/CMakeLists.txt
@@ -58,5 +58,3 @@ add_library(${PROJECT_NAME} STATIC
     ${pnpbridge_adapters_c_files}
     ${pnpbridge_adapters_h_files}
 )
-
-target_link_libraries(${PROJECT_NAME} ${pnp_bridge_common_libs})

--- a/pnpbridge/src/adapters/src/mqtt_pnp/CMakeLists.txt
+++ b/pnpbridge/src/adapters/src/mqtt_pnp/CMakeLists.txt
@@ -50,23 +50,4 @@ add_library(${PROJECT_NAME} STATIC
     ${pnpbridge_adapters_h_files}
 )
 
-set(pnp_bridge_common_libs
-    aziotsharedutil
-    pnpbridge
-    iothub_client 
-    iothub_client_http_transport
-    iothub_client_amqp_transport
-    iothub_client_amqp_ws_transport
-    iothub_client_mqtt_transport
-    iothub_client_mqtt_ws_transport
-    parson
-    umqtt
-    msr_riot
-    hsm_security_client
-    prov_auth_client
-    prov_device_client
-    prov_mqtt_transport
-    utpm
-)
 
-target_link_libraries(${PROJECT_NAME} ${pnp_bridge_common_libs})

--- a/pnpbridge/src/adapters/src/serial_pnp/CMakeLists.txt
+++ b/pnpbridge/src/adapters/src/serial_pnp/CMakeLists.txt
@@ -49,7 +49,6 @@ add_library(${PROJECT_NAME} STATIC
 )
 
 set(pnp_bridge_common_libs
-    aziotsharedutil
     pnpbridge
     iothub_client 
     iothub_client_http_transport

--- a/pnpbridge/src/pnpbridge/module/CMakeLists.txt
+++ b/pnpbridge/src/pnpbridge/module/CMakeLists.txt
@@ -72,9 +72,6 @@ add_definitions(-DPNP_LOGGING_ENABLED)
     # ${pnp_bridge_h_files}
 # )
 
-set(AZUREIOT_INC_FOLDER "/usr/include/azureiot" "/usr/include/azureiot/inc")
-
-include_directories(${AZUREIOT_INC_FOLDER})
 include_directories(inc)
 include_directories(common)
 include_directories(../../deps/azure-iot-sdk-c-pnp/deps/parson)

--- a/pnpbridge/src/pnpbridge/module/CMakeLists.txt
+++ b/pnpbridge/src/pnpbridge/module/CMakeLists.txt
@@ -104,7 +104,6 @@ set(pnp_bridge_common_libs
     ssl
     crypto
     m
-    uuid
     pnpbridge_adapters
     pnpbridge_modbus
     pnpbridge_mqtt


### PR DESCRIPTION
**Problem**
 - Bridge module build warnings: unsafe header/lib path in cross compilation:

```
[ 99%] Building C object src/pnpbridge/module/CMakeFiles/pnpbridge_module.dir/__/common/pnp_device_client.c.o
arm-none-linux-gnueabi-gcc: WARNING: unsafe header/library path used in cross-compilation: '-I/usr/include/azureiot'
arm-none-linux-gnueabi-gcc: WARNING: unsafe header/library path used in cross-compilation: '-I/usr/include/azureiot/inc'
[ 99%] Building C object src/pnpbridge/module/CMakeFiles/pnpbridge_module.dir/__/common/pnp_dps.c.o
arm-none-linux-gnueabi-gcc: WARNING: unsafe header/library path used in cross-compilation: '-I/usr/include/azureiot'
arm-none-linux-gnueabi-gcc: WARNING: unsafe header/library path used in cross-compilation: '-I/usr/include/azureiot/inc'
[ 99%] Building C object src/pnpbridge/module/CMakeFiles/pnpbridge_module.dir/__/common/pnp_protocol.c.o
arm-none-linux-gnueabi-gcc: WARNING: unsafe header/library path used in cross-compilation: '-I/usr/include/azureiot'
arm-none-linux-gnueabi-gcc: WARNING: unsafe header/library path used in cross-compilation: '-I/usr/include/azureiot/inc'
```
**Fix**
 - Remove redundant dependency of azureiot include paths from module cmake
 - Remove module dependency on uuid library

**Additionally**
 - Clean up adapter cmakes
 - Log only errors on telemetry callback in the BLE adapter

**Validation**
- [x] Build bridge as module targeting linux amd
- [x] Validate edge module support on linux amd
- [x] Build bridge as module targeting linux arm