### PR TITLE
Consuming optional use_sample_trusted_cert

### DIFF
--- a/pnpbridge/CMakeLists.txt
+++ b/pnpbridge/CMakeLists.txt
@@ -55,6 +55,12 @@ if(${use_edge_modules})
     set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -DUSE_EDGE_MODULES")
 endif()
 
+# Enable IoT SDK to act as a module for Edge
+if(${use_sample_trusted_cert})
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -DSET_TRUSTED_CERT")
+    set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -DSET_TRUSTED_CERT")
+endif()
+
 #Enable DPS Provisioning
 set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -DUSE_PROV_MODULE_FULL")
 set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -DUSE_PROV_MODULE_FULL")

--- a/pnpbridge/CMakeLists.txt
+++ b/pnpbridge/CMakeLists.txt
@@ -55,7 +55,7 @@ if(${use_edge_modules})
     set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -DUSE_EDGE_MODULES")
 endif()
 
-# Enable IoT SDK to act as a module for Edge
+# Enable optional trusted cert
 if(${use_sample_trusted_cert})
     set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -DSET_TRUSTED_CERT")
     set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -DSET_TRUSTED_CERT")

--- a/pnpbridge/src/pnpbridge/src/pnpbridge.c
+++ b/pnpbridge/src/pnpbridge/src/pnpbridge.c
@@ -165,7 +165,7 @@ PnpBridge_IsRunningInEdgeRuntime()
     bool dockerizedModule = false;
     const char * iotEdgeWorkLoadUri = getenv(g_workloadURIEnvironmentVariable);
     dockerizedModule = (iotEdgeWorkLoadUri != NULL);
-    LogInfo("%s", ((dockerizedModule) ? "Pnp Bridge is running in a dockerized edge module." : "Pnp Bridge is running as am IoT egde device."));
+    LogInfo("%s", ((dockerizedModule) ? "Pnp Bridge is running on an IoT edge module." : "Pnp Bridge is running on an IoT device."));
     return dockerizedModule;
 }
 


### PR DESCRIPTION
This change comprises of:
 - Adding the consumption of optional use_sample_trusted_cert flag for embedded devices.
 - Fixing some logging