### PR TITLE
Getting Property Updates to work with Serial Device

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,4 +6,11 @@
 /PnpBridge/src/PnpBridge/Debug
 /PnpBridge/src/PnpBridge/x64/Debug
 /PnpBridge/src/PnpBridge/PnpBridge.sln
+/PnPBridge/.vs
+/PnPBridge/out
+/PnPBridge/cmake
+/PnPBridge/CMakeSettings.json
+/cmake
+/out
+/deps
 .vscode

--- a/.gitignore
+++ b/.gitignore
@@ -5,12 +5,10 @@
 /PnpBridge/src/PnpBridge/.vs
 /PnpBridge/src/PnpBridge/Debug
 /PnpBridge/src/PnpBridge/x64/Debug
-/PnpBridge/src/PnpBridge/PnpBridge.sln
 /PnPBridge/.vs
 /PnPBridge/out
 /PnPBridge/cmake
 /PnPBridge/CMakeSettings.json
-/cmake
 /out
-/deps
+/PnPBridge/deps
 .vscode

--- a/pnpbridge/docs/schemas/grovearduinoserialpnpModel.json
+++ b/pnpbridge/docs/schemas/grovearduinoserialpnpModel.json
@@ -1,0 +1,74 @@
+
+{
+  "@context": "dtmi:dtdl:context;2",
+  "@id": "dtmi:com:contoso:serialpnp;1",
+  "@type": "Interface",
+  "displayName": "Pnp Bridge Root Interface Model serialpnp",
+  "description": "Arduino Serial PnP",
+  "comment": "Serial PnP for Arduino",
+  
+  "contents": [
+    {
+      "@type": "Property",
+      "displayName": "Sample Rate",
+      "description": "Rate of temperature readings.",
+      "name": "sample_rate",
+      "schema": "integer",
+      "writable": true
+    },
+    {
+      "@type": [
+      "Telemetry", 
+      "Temperature"
+      ],
+      "description": "Current temperature on the device",
+      "displayName": "Temperature",
+      "name": "temperature",
+      "schema": "float",
+      "unit": "degreeCelsius"
+    },
+    {
+      "@type": "Command",
+      "name": "calibrate",
+      "description": "Calibrates the thermometer.",
+      "commandType": "synchronous",
+      "request": {
+          "name": "input",
+          "schema": "integer"
+      },
+      "response": {
+        "name": "calibrateResponse",
+        "schema": "integer"
+      }  
+    },
+    {
+      "@type": "Command",
+      "name": "calibration",
+      "comment": "Enable-disable sampling.",
+      "commandType": "synchronous" ,
+      "request": {
+        "name": "input",
+        "schema": "integer"
+      },
+      "response": {
+        "name": "output",
+        "schema": "integer"
+      }  
+    },
+    {
+      "@type": "Command",
+      "name": "toggle_state",
+      "comment": "Enable-disable sampling.",
+      "commandType": "synchronous" ,
+      "request": {
+        "name": "input",
+        "schema": "integer"
+      },
+      "response": {
+        "name": "output",
+        "schema": "integer"
+      }  
+    }
+  ]
+
+}

--- a/pnpbridge/docs/schemas/grovearduinoserialpnpModel.json
+++ b/pnpbridge/docs/schemas/grovearduinoserialpnpModel.json
@@ -25,6 +25,14 @@
       "writable": false
     },
     {
+      "@type": "Property",
+      "displayName": "XXXX",
+      "description": "Dummy xxxx.",
+      "name": "xxxx",
+      "schema": "string",
+      "writable": false
+    },
+    {
       "@type": [
       "Telemetry", 
       "Temperature"
@@ -62,6 +70,16 @@
         "name": "output",
         "schema": "integer"
       }  
+    },
+    {
+      "@type": "Command",
+      "name": "toggle_properties",
+      "comment": "Enable-disable property upload with telemetry.",
+      "commandType": "synchronous" ,
+      "response": {
+        "name": "output",
+        "schema": "integer"
+      }   
     }
   ]
 

--- a/pnpbridge/docs/schemas/grovearduinoserialpnpModel.json
+++ b/pnpbridge/docs/schemas/grovearduinoserialpnpModel.json
@@ -17,6 +17,14 @@
       "writable": true
     },
     {
+      "@type": "Property",
+      "displayName": "Dummy",
+      "description": "Dummy readings.",
+      "name": "dummy",
+      "schema": "string",
+      "writable": false
+    },
+    {
       "@type": [
       "Telemetry", 
       "Temperature"
@@ -38,20 +46,6 @@
       },
       "response": {
         "name": "calibrateResponse",
-        "schema": "integer"
-      }  
-    },
-    {
-      "@type": "Command",
-      "name": "calibration",
-      "comment": "Enable-disable sampling.",
-      "commandType": "synchronous" ,
-      "request": {
-        "name": "input",
-        "schema": "integer"
-      },
-      "response": {
-        "name": "output",
         "schema": "integer"
       }  
     },

--- a/pnpbridge/src/adapters/src/serial_pnp/serial_pnp.c
+++ b/pnpbridge/src/adapters/src/serial_pnp/serial_pnp.c
@@ -263,17 +263,6 @@ char* SerialPnp_BinarySchemaToString(
     {
         sprintf_s(rxstrdata, MAXRXSTRLEN, "%d", *((int*)Data));
     }
-    // These next two are values that should be returned from toggle_properties on Arduino 2Do ???
-    else if ((Int == schema) && (*(int*)Data == SERIAL_PNP_RESPONSE_ON))
-    {
-        // When set by toggle
-        sprintf_s(rxstrdata, MAXRXSTRLEN, "%d", *((int*)Data));
-    }
-    else if ((Int == schema) && (*(int*)Data == SERIAL_PNP_RESPONSE_OFF))
-    {
-        // When clear by toggle
-        sprintf_s(rxstrdata, MAXRXSTRLEN, "%d", *((int*)Data));
-    }
     else if (((Boolean == schema) && (1 == length)))
     {
         sprintf_s(rxstrdata, MAXRXSTRLEN, "%d", *((int*)Data));
@@ -590,6 +579,37 @@ IOTHUB_CLIENT_RESULT SerialPnp_CommandHandler(
     Lock(serialDevice->CommandLock);
 
     const CommandDefinition* cmd = SerialPnp_LookupCommand(serialDevice->InterfaceDefinitions, command, 0);
+
+    //int lengthIn = 4; Not needed as SerialPnp_StringSchemaToBinary() returns it
+    //switch (cmd->RequestSchema)
+    //{
+    //    case Invalid:
+    //        lengthIn = 0;
+    //        break;
+    //    case Void:
+    //        lengthIn = 0;
+    //        break;
+    //    case Float:
+    //        lengthIn = 4;
+    //        break;
+    //    case Double:
+    //        lengthIn = 8;
+    //    case Int:
+    //        lengthIn = 4;
+    //        break;
+    //    case Boolean:
+    //        lengthIn = 1;
+    //        break;
+    //    case Long:
+    //        lengthIn = 4;
+    //        break;
+    //    case String:
+    //        // Get from length of input.
+    //        lengthIn = 0;
+    //        break;
+    //}
+
+
   
     byte* input = (byte*)data;
 
@@ -661,7 +681,37 @@ IOTHUB_CLIENT_RESULT SerialPnp_CommandHandler(
     byte* responsePacket = serialDevice->pbMainBuffer;
     int dataOffset = SERIALPNP_PACKET_NAME_OFFSET + nameLength;
     byte* commandResponse = responsePacket + dataOffset;
-    char* stval = SerialPnp_BinarySchemaToString(cmd->ResponseSchema, commandResponse, (byte)length);
+
+    int lengthOut = 4;
+    switch (cmd->ResponseSchema)
+    {
+    case Invalid:
+        lengthOut = 0;
+        break;
+    case Void:
+        lengthOut = 0;
+        break;
+    case Float:
+        lengthOut = 4;
+        break;
+    case Double:
+        lengthOut = 8;
+    case Int:
+        lengthOut = 4;
+        break;
+    case Boolean:
+        lengthOut = 1;
+        break;
+    case Long:
+        lengthOut = 4;
+        break;
+    case String:
+        // Get from length of output ??.
+        lengthOut = 0;
+        break;
+    }
+
+    char* stval = SerialPnp_BinarySchemaToString(cmd->ResponseSchema, commandResponse, (byte)lengthOut);
     free(inputPayload);
     free(responsePacket);
     free(txPacket);

--- a/pnpbridge/src/adapters/src/serial_pnp/serial_pnp.h
+++ b/pnpbridge/src/adapters/src/serial_pnp/serial_pnp.h
@@ -60,8 +60,16 @@ extern "C"
         Int,
         Long,
         Boolean,
-        String
+        String,
+        Void  // This allows for parameteless commands
     } Schema;
+
+    typedef enum SERIAL_PNP_RESPONSE
+    {
+        SERIAL_PNP_RESPONSE_ON = 250,
+        SERIAL_PNP_RESPONSE_OFF = 150
+    } SERIAL_PNP_RESPONSE;
+
 
     typedef struct FieldDefinition
     {
@@ -168,9 +176,7 @@ extern "C"
         PSERIAL_DEVICE_CONTEXT DeviceContext,
         char* TelemetryName,
         char* TelemetryData,
-        char** props,
-        char** vals,
-        int num_props);
+        JSON_Value* Properties);
 
     // Serial Pnp Adapter Config
     #define PNP_CONFIG_ADAPTER_SERIALPNP_COMPORT "com_port"

--- a/pnpbridge/src/adapters/src/serial_pnp/serial_pnp.h
+++ b/pnpbridge/src/adapters/src/serial_pnp/serial_pnp.h
@@ -4,6 +4,9 @@
 #include "azure_c_shared_utility/lock.h"
 #include "azure_c_shared_utility/condition.h"
 
+// Nb: Arduino code only for Win32
+#define ARDUINO_SERIAL
+
 #define MAX_BUFFER_SIZE 4096
 
 #define SERIALPNP_RESET_OR_DESCRIPTOR_MAX_RETRIES 3

--- a/pnpbridge/src/adapters/src/serial_pnp/serial_pnp.h
+++ b/pnpbridge/src/adapters/src/serial_pnp/serial_pnp.h
@@ -164,6 +164,14 @@ extern "C"
         char* TelemetryName,
         char* TelemetryData);
 
+    IOTHUB_CLIENT_RESULT SerialPnp_SendEventwithPropertiesAsync(
+        PSERIAL_DEVICE_CONTEXT DeviceContext,
+        char* TelemetryName,
+        char* TelemetryData,
+        char** props,
+        char** vals,
+        int num_props);
+
     // Serial Pnp Adapter Config
     #define PNP_CONFIG_ADAPTER_SERIALPNP_COMPORT "com_port"
     #define PNP_CONFIG_ADAPTER_SERIALPNP_USEDEFAULT "use_com_device_interface"

--- a/pnpbridge/src/pnpbridge/common/pnp_protocol.c
+++ b/pnpbridge/src/pnpbridge/common/pnp_protocol.c
@@ -216,6 +216,7 @@ static bool VisitDesiredObject(JSON_Object* desiredObject, const char** componen
         {
             const char* name = json_object_get_name(desiredObject, i);
             JSON_Value* value = json_object_get_value_at(desiredObject, i);
+            const char* component = componentsInModel[i];
 
             if (strcmp(name, g_IoTHubTwinDesiredVersion) == 0)
             {
@@ -233,7 +234,8 @@ static bool VisitDesiredObject(JSON_Object* desiredObject, const char** componen
             {
                 // If the child element is NOT an object OR its not a model the application knows about, this is a property of the model's root component.
                 // Invoke the application's passed in callback for it to process this property.
-                pnpPropertyCallback(NULL, name, value, version, userContextCallback);
+                //pnpPropertyCallback(NULL, name, value, version, userContextCallback);
+                pnpPropertyCallback(component, name, value, version, userContextCallback);
             }
         }
 

--- a/pnpbridge/src/pnpbridge/common/pnp_protocol.c
+++ b/pnpbridge/src/pnpbridge/common/pnp_protocol.c
@@ -81,7 +81,6 @@ STRING_HANDLE PnP_CreateReportedPropertyWithStatus(const char* componentName, co
 void PnP_ParseCommandName(const char* deviceMethodName, unsigned const char** componentName, size_t* componentNameSize, const char** pnpCommandName)
 {
     const char* separator;
-
     if ((separator = strchr(deviceMethodName, g_commandSeparator)) != NULL)
     {
         // If a separator character is present in the device method name, then a command on a subcomponent of 

--- a/pnpbridge/src/pnpbridge/common/pnp_protocol.c
+++ b/pnpbridge/src/pnpbridge/common/pnp_protocol.c
@@ -7,6 +7,8 @@
 // JSON parsing library
 #include "parson.h"
 
+IOTHUB_MESSAGE_RESULT IoTHubMessage_SetProperties(IOTHUB_MESSAGE_HANDLE iotHubMessageHandle, JSON_Value* _property);
+
 // IoT core utility related header files
 #include "azure_c_shared_utility/xlogging.h"
 #include "azure_c_shared_utility/strings.h"
@@ -99,11 +101,14 @@ void PnP_ParseCommandName(const char* deviceMethodName, unsigned const char** co
     }
 }
 
-IOTHUB_MESSAGE_HANDLE PnP_CreateTelemetrywithPropertiesMessageHandle(const char* componentName, const char* telemetryData, char ** properties, char ** values, int num_properties)
+IOTHUB_MESSAGE_HANDLE PnP_CreateTelemetrywithPropertiesMessageHandle(const char* componentName, const char* telemetryData, JSON_Value* _Properties)
 {
     IOTHUB_MESSAGE_HANDLE messageHandle;
     IOTHUB_MESSAGE_RESULT iothubMessageResult;
     bool result;
+
+    JSON_Array* leaves = json_value_get_array(_Properties);
+    size_t num_properties = json_array_get_count(leaves);
 
     if ((messageHandle = IoTHubMessage_CreateFromString(telemetryData)) == NULL)
     {
@@ -116,9 +121,9 @@ IOTHUB_MESSAGE_HANDLE PnP_CreateTelemetrywithPropertiesMessageHandle(const char*
         LogError("IoTHubMessage_SetProperty=%s failed, error=%d", PnP_TelemetryComponentProperty, iothubMessageResult);
         result = false;
     }
-    else if ((componentName != NULL) && (num_properties > 0) && (iothubMessageResult = IoTHubMessage_SetProperties(messageHandle, properties, values, num_properties)) != IOTHUB_MESSAGE_OK)
+    else if ((componentName != NULL) && (num_properties > 0) && (iothubMessageResult = IoTHubMessage_SetProperties(messageHandle, _Properties)) != IOTHUB_MESSAGE_OK)
     {
-        LogError("IoTHubMessage_SetProperties=%s failed, error=%d", properties[0], iothubMessageResult);
+        LogError("IoTHubMessage_SetProperties failed, error=%d", iothubMessageResult);
         result = false;
     }
     else

--- a/pnpbridge/src/pnpbridge/common/pnp_protocol.h
+++ b/pnpbridge/src/pnpbridge/common/pnp_protocol.h
@@ -78,7 +78,7 @@ void PnP_ParseCommandName(const char* deviceMethodName, unsigned const char** co
 // The application itself needs to send this to IoTHub, using a function such as IoTHubDeviceClient_SendEventAsync.
 //
 IOTHUB_MESSAGE_HANDLE PnP_CreateTelemetryMessageHandle(const char* componentName, const char* telemetryData);
-IOTHUB_MESSAGE_HANDLE PnP_CreateTelemetrywithPropertiesMessageHandle(const char* componentName, const char* telemetryData, char** properties, char** values, int num_properties);
+IOTHUB_MESSAGE_HANDLE PnP_CreateTelemetrywithPropertiesMessageHandle(const char* componentName, const char* telemetryData, JSON_Value* Properties);
 
 //
 // PnP_ProcessTwinData is invoked by the application when a device twin arrives to its device twin processing callback.

--- a/pnpbridge/src/pnpbridge/common/pnp_protocol.h
+++ b/pnpbridge/src/pnpbridge/common/pnp_protocol.h
@@ -78,6 +78,7 @@ void PnP_ParseCommandName(const char* deviceMethodName, unsigned const char** co
 // The application itself needs to send this to IoTHub, using a function such as IoTHubDeviceClient_SendEventAsync.
 //
 IOTHUB_MESSAGE_HANDLE PnP_CreateTelemetryMessageHandle(const char* componentName, const char* telemetryData);
+IOTHUB_MESSAGE_HANDLE PnP_CreateTelemetrywithPropertiesMessageHandle(const char* componentName, const char* telemetryData, char** properties, char** values, int num_properties);
 
 //
 // PnP_ProcessTwinData is invoked by the application when a device twin arrives to its device twin processing callback.

--- a/pnpbridge/src/pnpbridge/samples/console/main.c
+++ b/pnpbridge/src/pnpbridge/samples/console/main.c
@@ -51,8 +51,19 @@ int main(int argc, char *argv[])
     }
     else
     {
+#define USEARDUINO
+#ifdef USEDEFAULT
         LogInfo("Using default configuration location");
-        mallocAndStrcpy_s(&ConfigurationFilePath, (const char*) "config.json");
+        mallocAndStrcpy_s(&ConfigurationFilePath, (const char*)"config.json");
+#endif
+#ifdef USEENV
+        LogInfo("Using configuration in Env Debug");
+        mallocAndStrcpy_s(&ConfigurationFilePath, (const char*)"M:\\iot-bridges\\Azure-Version-Works\\iot-plug-and-play-bridge\\pnpbridge\\cmake\\pnpbridge_x86\\src\\pnpbridge\\samples\\console\\Debug\\config.json");
+#endif
+#ifdef USEARDUINO
+        LogInfo("Using default configuration location");
+        mallocAndStrcpy_s(&ConfigurationFilePath, (const char*)"M:\\iot-bridges\\Azure-Version-Works\\iot-plug-and-play-bridge\\pnpbridge\\cmake\\pnpbridge_x86\\src\\pnpbridge\\samples\\console\\Debug\\arduino-config.json");
+#endif
     }
 
     PnpBridge_Main((const char*)ConfigurationFilePath);

--- a/pnpbridge/src/pnpbridge/src/pnpadapter_manager.c
+++ b/pnpbridge/src/pnpbridge/src/pnpadapter_manager.c
@@ -639,12 +639,12 @@ int PnpAdapterManager_DeviceMethodCallback(
                             LogInfo("No components found in model");
                     }
         }
-        if (componentName == NULL)
-        {
-            // Or just insert it. In this case serailpnp
-            componentName = "seriapnp";
-            componentNameSize = strlen(componentName);
-        }         
+        ////if (componentName == NULL)
+        ////{
+        ////    // Or just insert it. In this case serailpnp
+        ////    componentName = "seriapnp";
+        ////    componentNameSize = strlen(componentName);
+        ////}         
         if (componentName != NULL)
         {
             LogInfo("Received PnP command for component=%.*s, command=%s", (int)componentNameSize, componentName, pnpCommandName);

--- a/pnpbridge/src/pnpbridge/src/pnpadapter_manager.c
+++ b/pnpbridge/src/pnpbridge/src/pnpadapter_manager.c
@@ -660,6 +660,8 @@ int PnpAdapterManager_DeviceMethodCallback(
                 LogInfo("Pnp Bridge does not have a suitable adapter to route %s's method twin callback to at this time.", componentName);
             }
         }
+        else
+            LogInfo("PnP Bridge: No Component for Device Command Callback for command=%s", pnpCommandName);
     }
     return result;
 }

--- a/pnpbridge/src/pnpbridge/src/pnpadapter_manager.c
+++ b/pnpbridge/src/pnpbridge/src/pnpadapter_manager.c
@@ -641,7 +641,7 @@ int PnpAdapterManager_DeviceMethodCallback(
         }
         ////if (componentName == NULL)
         ////{
-        ////    // Or just insert it. In this case serailpnp
+        ////    // Or just insert it. In this case serialpnp
         ////    componentName = "seriapnp";
         ////    componentNameSize = strlen(componentName);
         ////}         


### PR DESCRIPTION
Two issues as discussed in [More issues with the Arduino Serial example #74](https://github.com/Azure/iot-plug-and-play-bridge/issues/74)
(1) Can only push string properties back from Azure IoT Explorer .. Updated for string, int and bool
(2)  At one point a null component is always used which means it can't be found and so update doesn't happen.  But the component is supplied when that function is called so use it.

**re (1)**

**In \iot-plug-and-play-bridge\pnpbridge\src\adapters\src\serial_pnp\serial_pnp.c**

_Change_ 
```
const char * PropertyValueString = json_value_get_string(PropertyValue);
```

To:
```
    char* PropertyValueString = NULL;
    const char* propertyValueString;
    if (json_value_get_type(PropertyValue) == JSONString)
    {
  ...
    }
    else if (json_value_get_type(PropertyValue) == JSONNumber)
    {
  ...
    }
    else if (json_value_get_type(PropertyValue) == JSONBoolean)
    {
   ...
    }
```

**Re: (2)**
**In \iot-plug-and-play-bridge\pnpbridge\src\pnpbridge\common\pnp_protocol.c**

In ```VisitDesiredObject( )```

This call always fails with NULL. Need a  Component:
```
pnpPropertyCallback(NULL, name, value, version, userContextCallback);
```

(i) Line 238 Change NULL to component: 
```
pnpPropertyCallback(component , name, value, version, userContextCallback);
```

Then get the component from the **componentsInModel** parameter passed to the function

(ii) Insert after line 218 
```
const char* component = componentsInModel[i];
```

**_Property updates from Az IoT Explorer now work with the Arduino Sample._**


====================


Nb: Also this Pull Request updates .gitignore so as to preclude cmake generated.files